### PR TITLE
Fixed automatic switch exception

### DIFF
--- a/luci-app-ssr-plus/root/usr/bin/ssr-switch
+++ b/luci-app-ssr-plus/root/usr/bin/ssr-switch
@@ -35,6 +35,15 @@ uci_get_by_type() {
 DEFAULT_SERVER=$(uci_get_by_type global global_server)
 CURRENT_SERVER=$DEFAULT_SERVER
 
+#获取服务器ip
+server2ip() {
+    if [[ $1 =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        echo $1
+    else
+        echo $(nslookup $1 | grep 'Address 1' | awk -F ': ' '{ print $2 }')
+    fi
+}
+
 #判断代理是否正常
 check_proxy() {
 	local result=0
@@ -62,16 +71,18 @@ check_proxy() {
 test_proxy() {
 	local servername=$(uci_get_by_name $1 server)
 	local serverport=$(uci_get_by_name $1 server_port)
+	local serverip=$(server2ip $servername)
+	ipset add ss_spec_wan_ac $serverip 2>/dev/null
+	ret_ac=$?
 	ret=$(tcpping -c 3 -p $serverport $servername | grep 'loss' | awk -F ',' '{ print $3 }' | awk -F "%" '{ print $1 }' | awk -F "." '{ print $1 }')
-	[ -z "$ret" ] && return 1
-	[ "$ret" -gt "50" ] && return 1
-	ipset add ss_spec_wan_ac $servername 2>/dev/null
-	ret=$?
+	#echo "$(date "+%Y-%m-%d %H:%M:%S") test_proxy> name: $servername, ip: $serverip, ret_ac: $ret_ac, ret_tcpping: $ret" >> /tmp/ssrplus.log
+	if [ -z "$ret" ] || [ "$ret" -gt "50" ]; then
+		[ "$ret_ac" == "0" ] && ipset del ss_spec_wan_ac $serverip 2>/dev/null
+		return 1
+	fi
 	/usr/bin/ssr-check $servername $serverport $switch_time
 	local ret2=$?
-	if [ "$ret" == "0" ]; then
-		ipset del ss_spec_wan_ac $servername 2>/dev/null
-	fi
+	[ "$ret_ac" == "0" ] && ipset del ss_spec_wan_ac $serverip 2>/dev/null
 	if [ "$ret2" == "0" ]; then
 		return 0
 	else
@@ -87,12 +98,13 @@ search_proxy() {
 	[ "$1" == "$CURRENT_SERVER" ] && return 0
 	local servername=$(uci_get_by_name $1 server)
 	local serverport=$(uci_get_by_name $1 server_port)
-	ipset add ss_spec_wan_ac $servername 2>/dev/null
+	local serverip=$(server2ip $servername)
+	ipset add ss_spec_wan_ac $serverip 2>/dev/null
 	ret=$?
 	/usr/bin/ssr-check $servername $serverport $switch_time
 	local ret2=$?
 	if [ "$ret" == "0" ]; then
-		ipset del ss_spec_wan_ac $servername 2>/dev/null
+		ipset del ss_spec_wan_ac $serverip 2>/dev/null
 	fi
 	if [ "$ret2" == "0" ]; then
 		server_locate=$server_count

--- a/luci-app-ssr-plus/root/usr/bin/ssr-switch
+++ b/luci-app-ssr-plus/root/usr/bin/ssr-switch
@@ -35,13 +35,21 @@ uci_get_by_type() {
 DEFAULT_SERVER=$(uci_get_by_type global global_server)
 CURRENT_SERVER=$DEFAULT_SERVER
 
-#获取服务器ip
-server2ip() {
-    if [[ $1 =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-        echo $1
-    else
-        echo $(nslookup $1 | grep 'Address 1' | awk -F ': ' '{ print $2 }')
-    fi
+#解析ip
+get_host_ip() {
+	local host=$1
+	local isip=""
+	local ip=$host
+	isip=$(echo $host | grep -E "([0-9]{1,3}[\.]){3}[0-9]{1,3}")
+	if [ -z "$isip" ]; then
+		if [ "$host" != "${host#*:[0-9a-fA-F]}" ]; then
+			ip=$host
+		else
+			local ip=$(resolveip -4 -t 3 $host | awk 'NR==1{print}')
+			[ -z "$ip" ] && ip=$(wget -q -O- http://119.29.29.29/d?dn=$1 | awk -F ';' '{print $1}')
+		fi
+	fi
+	echo ${ip:="ERROR"}
 }
 
 #判断代理是否正常
@@ -69,20 +77,19 @@ check_proxy() {
 }
 
 test_proxy() {
-	local servername=$(uci_get_by_name $1 server)
+	local servername=$(get_host_ip $(uci_get_by_name $1 server))
 	local serverport=$(uci_get_by_name $1 server_port)
-	local serverip=$(server2ip $servername)
-	ipset add ss_spec_wan_ac $serverip 2>/dev/null
-	ret_ac=$?
+	ipset add ss_spec_wan_ac $servername 2>/dev/null
+	ret1=$?
 	ret=$(tcpping -c 3 -p $serverport $servername | grep 'loss' | awk -F ',' '{ print $3 }' | awk -F "%" '{ print $1 }' | awk -F "." '{ print $1 }')
-	#echo "$(date "+%Y-%m-%d %H:%M:%S") test_proxy> name: $servername, ip: $serverip, ret_ac: $ret_ac, ret_tcpping: $ret" >> /tmp/ssrplus.log
+	#echo "$(date "+%Y-%m-%d %H:%M:%S") test_proxy> name: $servername, ret1: $ret1, ret: $ret" >> /tmp/ssrplus.log
 	if [ -z "$ret" ] || [ "$ret" -gt "50" ]; then
-		[ "$ret_ac" == "0" ] && ipset del ss_spec_wan_ac $serverip 2>/dev/null
+		[ "$ret1" == "0" ] && ipset del ss_spec_wan_ac $servername 2>/dev/null
 		return 1
 	fi
 	/usr/bin/ssr-check $servername $serverport $switch_time
 	local ret2=$?
-	[ "$ret_ac" == "0" ] && ipset del ss_spec_wan_ac $serverip 2>/dev/null
+	[ "$ret1" == "0" ] && ipset del ss_spec_wan_ac $servername 2>/dev/null
 	if [ "$ret2" == "0" ]; then
 		return 0
 	else
@@ -96,16 +103,13 @@ search_proxy() {
 	[ "$(uci_get_by_name $1 switch_enable 0)" != "1" ] && return 1
 	[ $ENABLE_SERVER != nil ] && return 0
 	[ "$1" == "$CURRENT_SERVER" ] && return 0
-	local servername=$(uci_get_by_name $1 server)
+	local servername=$(get_host_ip $(uci_get_by_name $1 server))
 	local serverport=$(uci_get_by_name $1 server_port)
-	local serverip=$(server2ip $servername)
-	ipset add ss_spec_wan_ac $serverip 2>/dev/null
+	ipset add ss_spec_wan_ac $servername 2>/dev/null
 	ret=$?
 	/usr/bin/ssr-check $servername $serverport $switch_time
 	local ret2=$?
-	if [ "$ret" == "0" ]; then
-		ipset del ss_spec_wan_ac $serverip 2>/dev/null
-	fi
+	[ "$ret" == "0" ] && ipset del ss_spec_wan_ac $servername 2>/dev/null
 	if [ "$ret2" == "0" ]; then
 		server_locate=$server_count
 		ENABLE_SERVER=$1


### PR DESCRIPTION
Fix #93 
`tcpping` (#37 ) may go through the proxy, showing 100% packet loss. So put it after the `ipset add ss_spec_wan_ac`.
`ipset` cannot accept domain directly. So transform it to IP.