### PR TITLE
fix symbolic link of i18n

### DIFF
--- a/luci-app-ssr-plus/po/zh_Hans
+++ b/luci-app-ssr-plus/po/zh_Hans
@@ -1,1 +1,1 @@
-po/zh-cn
+zh-cn


### PR DESCRIPTION
软链接的源路径错了