### PR TITLE
Add port 9418 for cloning repositories using git:// protocol

### DIFF
--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -676,7 +676,7 @@ start_rules() {
 	if [ $dports == "1" ]; then
 		proxyport=" "
 	else
-		proxyport="-m multiport --dports 22,53,587,465,995,993,143,80,443,853"
+		proxyport="-m multiport --dports 22,53,587,465,995,993,143,80,443,853,9418"
 	fi
 	if [ "$NETFLIX_SERVER" != "nil" ]; then
 		if [ "$NETFLIX_SERVER" != "$GLOBAL_SERVER" ]; then


### PR DESCRIPTION
Since port 9418 is used while cloning repositories with git:// protocol, it need to be proxied. See https://docs.github.com/en/enterprise-server@2.21/admin/configuration/network-ports#application-ports-for-end-users for more info.