### PR TITLE
remove the logic to check default server when switching server

### DIFF
--- a/luci-app-ssr-plus/root/usr/bin/ssr-switch
+++ b/luci-app-ssr-plus/root/usr/bin/ssr-switch
@@ -109,22 +109,6 @@ start() {
 	while [ "1" == "1" ]; do #死循环
 		sleep 0000$cycle_time
 		LOGTIME=$(date "+%Y-%m-%d %H:%M:%S")
-		#判断当前代理是否为缺省服务器
-		if [ "$CURRENT_SERVER" != "$DEFAULT_SERVER" ]; then
-			#echo "not default proxy"
-			echolog "Current server is not default Main server, try to switch back."
-			#检查缺省服务器是否正常
-			if test_proxy $DEFAULT_SERVER; then
-				#echo "switch to default proxy"
-				echolog "Main server is avilable."
-				#缺省服务器正常，切换回来
-				CURRENT_SERVER=$DEFAULT_SERVER
-				switch_proxy $CURRENT_SERVER
-				echolog "switch to default "$(uci_get_by_name $CURRENT_SERVER alias)" proxy!"
-			else
-				echolog "Main server is NOT avilable.Continue using current server."
-			fi
-		fi
 		#判断当前代理是否正常
 		#echolog "Start checking if the current server is available."
 		check_proxy


### PR DESCRIPTION
## what
在进行服务器自动切换时，移除对默认服务器节点的检查。

## why
开启了自动切换功能后，服务器节点总是跳回默认节点，似乎是这里的逻辑不太正确。

日志(截取的路由器日志，敏感信息已经隐藏，注意是时间倒序)：
```
...
2021-01-21 00:46:33: Another server is avilable, now switching server.
2021-01-21 00:46:33: Current server error, try to switch another server.
2021-01-20 21:44:41: switch to default *** proxy!
2021-01-20 21:44:41: -----------end------------
2021-01-20 21:44:36: Main node:ShadowsocksR 4 Threads Started!
2021-01-20 21:44:36: ----------start------------
2021-01-20 21:44:34: Main server is avilable.
2021-01-20 21:44:31: Current server is not default Main server, try to switch back.
2021-01-20 21:44:01: Switch to *** proxy!
2021-01-20 21:44:01: -----------end------------
2021-01-20 21:43:57: Main node:ShadowsocksR 4 Threads Started!
2021-01-20 21:43:57: ----------start------------
2021-01-20 21:43:55: Another server is avilable, now switching server.
2021-01-20 21:43:55: Current server error, try to switch another server.
2021-01-20 19:44:34: -----------end------------
2021-01-20 19:44:24: Main node:ShadowsocksR 4 Threads Started!
2021-01-20 19:44:24: ----------start------------
2021-01-20 19:44:24: boot！
```

还有大量日志，内容就是以上日志的反复。
我对shell 不太熟悉，不知道这个PR能否解决问题，请指教。