### PR TITLE
disable pdnsd ipv6 query

### DIFF
--- a/luci-app-ssr-plus/Makefile
+++ b/luci-app-ssr-plus/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ssr-plus
 PKG_VERSION:=183
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 define Package/$(PKG_NAME)/conffiles
 /etc/config/shadowsocksr

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -202,6 +202,7 @@ start_dns() {
 			uptest=none;
 			interval=10m;
 			purge_cache=off;
+			reject=::/0;
 			}
 		EOF
 		ln_start_bin $(first_type pdnsd) pdnsd -c $TMP_PATH/pdnsd.conf


### PR DESCRIPTION
Disable IPv6 queries only for proxied domains. All other queries will not be affected.