### PR TITLE
netflix端口修正

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
@@ -51,7 +51,7 @@ o = s:option(Value, "adblock_url", translate("adblock_url"))
 o:value("https://ghproxy.com/https://raw.githubusercontent.com/neodevpro/neodevhost/master/lite_host_dnsmasq.conf", translate("NEO DEV HOST Lite"))
 o:value("https://ghproxy.com/https://raw.githubusercontent.com/neodevpro/neodevhost/master/host_dnsmasq.conf", translate("NEO DEV HOST Full"))
 o:value("https://ghproxy.com/https://raw.githubusercontent.com/privacy-protection-tools/anti-AD/master/adblock-for-dnsmasq.conf", translate("anti-AD"))
-o.default = "https://ghproxy.com/https://raw.githubusercontent.com/neodevpro/neodevhost/master/lite_host_dnsmasq.conf"
+o.default = "https://ghproxy.com/https://raw.githubusercontent.com/privacy-protection-tools/anti-AD/master/adblock-for-dnsmasq.conf"
 o:depends("adblock", "1")
 o.description = translate("Support AdGuardHome and DNSMASQ format list")
 

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -888,7 +888,7 @@ reset() {
 		set shadowsocksr.@global[0].gfwlist_url='https://ghproxy.com/https://raw.githubusercontent.com/YW5vbnltb3Vz/domain-list-community/release/gfwlist.txt'
 		set shadowsocksr.@global[0].chnroute_url='https://ispip.clang.cn/all_cn.txt'
 		set shadowsocksr.@global[0].nfip_url='https://ghproxy.com/https://raw.githubusercontent.com/QiuSimons/Netflix_IP/master/NF_only.txt'
-		set shadowsocksr.@global[0].adblock_url='https://anti-ad.net/anti-ad-for-dnsmasq.conf'
+		set shadowsocksr.@global[0].adblock_url='https://ghproxy.com/https://raw.githubusercontent.com/privacy-protection-tools/anti-AD/master/adblock-for-dnsmasq.conf'
 		add shadowsocksr server_subscribe
 		set shadowsocksr.@server_subscribe[0].proxy='0'
 		set shadowsocksr.@server_subscribe[0].auto_update_time='2'

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -772,7 +772,7 @@ start_rules() {
 		2) echo "-O" ;;
 		esac
 	}
-	/usr/share/shadowsocksr/gfw2ipset.sh
+	/usr/share/shadowsocksr/gfw2ipset.sh $GLOBAL_SERVER
 	/usr/bin/ssr-rules \
 		-s "$server" \
 		-l "$local_port" \

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gfw2ipset.sh
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gfw2ipset.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 . $IPKG_INSTROOT/etc/init.d/shadowsocksr
+GLOBAL_SERVER=$1
 netflix() {
 	if [ -f "$TMP_DNSMASQ_PATH/gfw_list.conf" ]; then
 		for line in $(cat /etc/ssrplus/netflix.list); do sed -i "/$line/d" $TMP_DNSMASQ_PATH/gfw_list.conf; done
@@ -18,7 +19,7 @@ case "$(uci_get_by_type global netflix_server nil)" in
 nil)
 	rm -f $TMP_DNSMASQ_PATH/netflix_forward.conf
 	;;
-$(uci_get_by_type global global_server nil) | same)
+$GLOBAL_SERVER | same)
 	netflix $dns_port
 	;;
 *)


### PR DESCRIPTION
helloworld/luci-app-ssr-plus/root/usr/share/shadowsocksr/gfw2ipset.sh
这个文件中
case "$(uci_get_by_type global netflix_server nil)" in
nil)
rm -f $TMP_DNSMASQ_PATH/netflix_forward.conf
;;
$(uci_get_by_type global global_server nil) | same)
netflix $dns_port
;;
*)
netflix $tmp_shunt_dns_port
;;
这一段$(uci_get_by_type global global_server nil) | same)判断问题
当主服务器故障切换到与netflix分流相同的服务器时，这边判断的是配置中的服务器，导致netflix端口判断错误，