### PR TITLE
Fix VLESS http/2 bug & Make the behavior of import VLESS link and VLESS subscribe the same

### DIFF
--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
@@ -310,7 +310,7 @@ function import_ssr_url(btn, urlname, sid) {
 			document.getElementsByName('cbid.shadowsocksr.' + sid + '.server')[0].value = serverPart[0];
 			document.getElementsByName('cbid.shadowsocksr.' + sid + '.server_port')[0].value = port;
 			document.getElementsByName('cbid.shadowsocksr.' + sid + '.vmess_id')[0].value = uuid;
-			document.getElementsByName('cbid.shadowsocksr.' + sid + '.transport')[0].value = queryParam.type || "tcp";
+			document.getElementsByName('cbid.shadowsocksr.' + sid + '.transport')[0].value = queryParam.type ? (queryParam.type == "http" ? "h2" : queryParam.type) : "tcp";
 			document.getElementsByName('cbid.shadowsocksr.' + sid + '.transport')[0].dispatchEvent(event);
 			document.getElementsByName('cbid.shadowsocksr.' + sid + '.vless_encryption')[0].value = queryParam.encryption || "none";
 			if (queryParam.security == "tls") {
@@ -321,7 +321,7 @@ function import_ssr_url(btn, urlname, sid) {
 			switch (queryParam.type) {
 			case "ws":
 				document.getElementsByName('cbid.shadowsocksr.' + sid + '.ws_host')[0].value = queryParam.host;
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.ws_path')[0].value = queryParam.path;
+				document.getElementsByName('cbid.shadowsocksr.' + sid + '.ws_path')[0].value = queryParam.path || "/";
 				break;
 			case "kcp":
 				document.getElementsByName('cbid.shadowsocksr.' + sid + '.kcp_guise')[0].value = queryParam.headerType || "none";
@@ -329,13 +329,13 @@ function import_ssr_url(btn, urlname, sid) {
 				document.getElementsByName('cbid.shadowsocksr.' + sid + '.seed')[0].value = queryParam.seed;
 				break;
 			case "http":
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.h2_host')[0].value = queryParam.host;
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.h2_path')[0].value = queryParam.path;
+				document.getElementsByName('cbid.shadowsocksr.' + sid + '.h2_host')[0].value = queryParam.host || serverPart[0];
+				document.getElementsByName('cbid.shadowsocksr.' + sid + '.h2_path')[0].value = queryParam.path || "/";
 				break;
 			case "quic":
 				document.getElementsByName('cbid.shadowsocksr.' + sid + '.quic_guise')[0].value = queryParam.headerType || "none";
 				document.getElementsByName('cbid.shadowsocksr.' + sid + '.quic_guise')[0].dispatchEvent(event);
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.quic_security')[0].value = queryParam.quicSecurity;
+				document.getElementsByName('cbid.shadowsocksr.' + sid + '.quic_security')[0].value = queryParam.quicSecurity || "none";
 				document.getElementsByName('cbid.shadowsocksr.' + sid + '.quic_key')[0].value = queryParam.key;
 				break;
 			default:

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -280,7 +280,7 @@ local function processData(szType, content)
 			result.server_port = query[1]
 			result.vmess_id = uuid
 			result.vless_encryption = params.encryption or "none"
-			result.transport = params.type or "tcp"
+			result.transport = params.type and (params.type == 'http' and 'h2' or params.type) or "tcp"
 			if not params.type or params.type == "tcp" then
 				if params.security == "xtls" then
 					result.xtls = "1"


### PR DESCRIPTION
1. Fix VLESS http/2 bug.

VLESS链接中的type是http，但Luci中的值为h2，这里做了一个判断修改。

2. Make the behavior of import VLESS link and VLESS subscribe the same

VLESS导入链接和订阅之间默认值有一些不同，这里修改使它们的行为大致相同。