### PR TITLE
make it compatible with other ps program

### DIFF
--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -44,6 +44,7 @@ CRON_FILE=/etc/crontabs/root
 EXTRA_COMMANDS='reset'
 EXTRA_HELP="        reset   Reset to default settings"
 #extra_command "reset" "Reset to default settings"
+PS="/bin/busybox ps"
 
 uci_get_by_name() {
 	local ret=$(uci get $NAME.$1.$2 2>/dev/null)
@@ -840,13 +841,13 @@ stop() {
 		iptables -X SSR-SERVER-RULE 2>/dev/null
 	fi
 	if [ -z "$switch_server" ]; then
-		ps -w | grep -v "grep" | grep ssr-switch | awk '{print $1}' | xargs kill -9 >/dev/null 2>&1 &
+		$PS -w | grep -v "grep" | grep ssr-switch | awk '{print $1}' | xargs kill -9 >/dev/null 2>&1 &
 		rm -f /var/lock/ssr-switch.lock
 		killall -q -9 kcptun-client
 	fi
-	ps -w | grep -v "grep" | grep ssr-monitor | awk '{print $1}' | xargs kill -9 >/dev/null 2>&1 &
-	ps -w | grep -v "grep" | grep "sleep 0000" | awk '{print $1}' | xargs kill -9 >/dev/null 2>&1 &
-	ps -w | grep -v "grep" | grep "$TMP_PATH" | awk '{print $1}' | xargs kill -9 >/dev/null 2>&1 &
+	$PS -w | grep -v "grep" | grep ssr-monitor | awk '{print $1}' | xargs kill -9 >/dev/null 2>&1 &
+	$PS -w | grep -v "grep" | grep "sleep 0000" | awk '{print $1}' | xargs kill -9 >/dev/null 2>&1 &
+	$PS -w | grep -v "grep" | grep "$TMP_PATH" | awk '{print $1}' | xargs kill -9 >/dev/null 2>&1 &
 	killall -q -9 v2ray-plugin obfs-local xray-plugin
 	rm -f /var/lock/ssr-monitor.lock
 	if [ -f "/var/dnsmasq.d/dnsmasq-ssrplus.conf" ]; then


### PR DESCRIPTION
After installing procps-ng-ps, the ps command is not killing process when restarting. The consquence is there will be too many xray or v2ray process started which leads to a broken proxied network. To avoid this, we make ssr-plus to explicitly use busybox ps program.

Sample output from _procps-ng-ps_ version "ps -w"
[root@openwrt:~]$ ps -w
  PID TTY          TIME CMD
13311 pts/0    00:00:00 bash
14224 pts/0    00:00:00 ps

Sample output from _busybox_ version "ps -w"
[root@openwrt:~]$ /bin/busybox ps -w
  PID USER       VSZ STAT COMMAND
...
 4424 root     4805m S    /var/etc/ssrplus/bin/v2ray -config /var/etc/ssrplus/tcp-only-ssr-retcp.json
 5341 nobody    1980 S    /var/etc/ssrplus/bin/pdnsd -c /var/etc/ssrplus/pdnsd.conf
...

Sample output of ps symbolic link.
[root@openwrt:~]$ ll /bin/ps
lrwxrwxrwx    1 root     root            25 Apr 16 22:19 /bin/ps -> /usr/libexec/ps-procps-ng*