### PR TITLE
Use curl instead of socket when transport is "ws; Change "Apply "to "Reapply" when the node is used

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/servers.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/servers.lua
@@ -104,6 +104,14 @@ end
 o = s:option(DummyValue, "server_port", translate("Socket Connected"))
 o.template = "shadowsocksr/socket"
 o.width = "10%"
+o.render = function(self, section, scope)
+	self.transport = s:cfgvalue(section).transport
+	if self.transport == 'ws' then
+		self.ws_path = s:cfgvalue(section).ws_path
+		self.tls = s:cfgvalue(section).tls
+	end
+	DummyValue.render(self, section, scope)
+end
 
 o = s:option(DummyValue, "server", translate("Ping Latency"))
 o.template = "shadowsocksr/ping"

--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/servers.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/servers.lua
@@ -109,8 +109,18 @@ o = s:option(DummyValue, "server", translate("Ping Latency"))
 o.template = "shadowsocksr/ping"
 o.width = "10%"
 
+local global_server = uci:get_first('shadowsocksr', 'global', 'global_server') 
+
 node = s:option(Button, "apply_node", translate("Apply"))
 node.inputstyle = "apply"
+node.render = function(self, section, scope)
+	if section == global_server then
+		self.title = translate("Reapply")
+	else
+		self.title = translate("Apply")
+	end
+	Button.render(self, section, scope)
+end
 node.write = function(self, section)
 	uci:set("shadowsocksr", '@global[0]', 'global_server', section)
 	uci:save("shadowsocksr")

--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/server_list.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/server_list.htm
@@ -5,17 +5,26 @@
 <script type="text/javascript">
 	//<![CDATA[
 	const doms = document.getElementsByClassName('pingtime');
-	const ports = document.getElementsByClassName("socket-connected")
+	const ports = document.getElementsByClassName("socket-connected");
+	const transports = document.getElementsByClassName("transport");
+	const wsPaths = document.getElementsByClassName("wsPath");
+	const tlss = document.getElementsByClassName("tls");
 	const xhr = (index) => {
 		return new Promise((res) => {
 			const dom = doms[index];
 			const port = ports[index];
+			const transport = transports[index];
+			const wsPath = wsPaths[index];
+			const tls = tlss[index];
 			if (!dom) res()
 			port.innerHTML = '<font color="#0072c3">connect</font>';
 			XHR.get('<%=luci.dispatcher.build_url("admin/services/shadowsocksr/ping")%>', {
 				index,
 				domain: dom.getAttribute("hint"),
-				port: port.getAttribute("hint")
+				port: port.getAttribute("hint"),
+				transport: transport.getAttribute("hint"),
+				wsPath: wsPath.getAttribute("hint"),
+				tls: tls.getAttribute("hint")
 			},
 			(x, result) => {
 				let col = '#ff0000';

--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/socket.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/socket.htm
@@ -1,3 +1,6 @@
 <%+cbi/valueheader%>
 <span class="socket-connected" hint="<%=self:cfgvalue(section)%>">wait</span>
+<span class="transport" hint="<%=self.transport%>"></span>
+<span class="wsPath" hint="<%=self.ws_path%>"></span>
+<span class="tls" hint="<%=self.tls%>"></span>
 <%+cbi/valuefooter%>

--- a/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
@@ -741,3 +741,6 @@ msgstr "重置pdnsd缓存"
 
 msgid "Finger Print"
 msgstr "指纹伪造"
+
+msgid "Reapply"
+msgstr "重新应用"


### PR DESCRIPTION
1. 当正在使用该节点时，将Apply改为Reapply。
![image](https://user-images.githubusercontent.com/19186382/121801883-428cf380-cc6c-11eb-8448-9325bd54eefe.png)

2. 使用curl取代nixio.socket()来测试websocket连接：因为websocket可以使用path(ws_path)来区分服务，nixio.socket()只能测试端口是否连通，但无法测试websocket服务是否正常。
使用curl测试websocket的教程：[Test a WebSocket using curl](https://gist.github.com/htp/fbce19069187ec1cc486b594104f01d0)