### PR TITLE
fix(luci-app-ssr-plus): Add the '-k' param to the curl command

### DIFF
--- a/luci-app-ssr-plus/luasrc/controller/shadowsocksr.lua
+++ b/luci-app-ssr-plus/luasrc/controller/shadowsocksr.lua
@@ -54,7 +54,7 @@ function act_ping()
 	if transport == "ws" then
 		local prefix = tls=='1' and "https://" or "http://"
 		local address = prefix..domain..':'..port..wsPath
-		local result = luci.sys.exec("curl --http1.1 -m 3 -s  -i -N -o /dev/null -w 'time_connect=%{time_connect}\nhttp_code=%{http_code}' -H 'Connection: Upgrade' -H 'Upgrade: websocket' -H 'Sec-WebSocket-Key: SGVsbG8sIHdvcmxkIQ==' -H 'Sec-WebSocket-Version: 13' "..address)
+		local result = luci.sys.exec("curl --http1.1 -m 2 -ksN -o /dev/null -w 'time_connect=%{time_connect}\nhttp_code=%{http_code}' -H 'Connection: Upgrade' -H 'Upgrade: websocket' -H 'Sec-WebSocket-Key: SGVsbG8sIHdvcmxkIQ==' -H 'Sec-WebSocket-Version: 13' "..address)
 		e.socket = string.match(result,"http_code=(%d+)")=="101"
 		e.ping = tonumber(string.match(result, "time_connect=(%d+.%d%d%d)"))*1000
 	else


### PR DESCRIPTION
Allow curl to proceed handling an insecure server connection
有些节点使用自签名或过期的ssl/tls证书，导致curl无法继续运行，所以添加参数`-k`忽略证书校验错误
fix #561