### PR TITLE
Fix up reject ipv6 cache issues

### DIFF
--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -202,6 +202,7 @@ start_dns() {
 			interval=10m;
 			purge_cache=off;
 			reject=::/0;
+			reject_policy=negate;
 			}
 		EOF
 		ln_start_bin $(first_type pdnsd) pdnsd -c $TMP_PATH/pdnsd.conf

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -203,6 +203,7 @@ start_dns() {
 			purge_cache=off;
 			reject=::/0;
 			reject_policy=negate;
+			reject_recursively=on;
 			}
 		EOF
 		ln_start_bin $(first_type pdnsd) pdnsd -c $TMP_PATH/pdnsd.conf


### PR DESCRIPTION
pdnsd缓存不生效.因为 reject策略问题