### PR TITLE
luci-app-ssr-plus: revert commit #610

### DIFF
--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -201,9 +201,6 @@ start_dns() {
 			uptest=none;
 			interval=10m;
 			purge_cache=off;
-			reject=::/0;
-			reject_policy=negate;
-			reject_recursively=on;
 			}
 		EOF
 		ln_start_bin $(first_type pdnsd) pdnsd -c $TMP_PATH/pdnsd.conf


### PR DESCRIPTION
This patch caused the #615 and #612 issues.

Before fixing the PDNSD ipv6 filter mode, users can use dnsmasq reject ipv6 mode instead.