### PR TITLE
fix restart/reload when use luci-nginx

### DIFF
--- a/luci-app-ssr-plus/root/etc/uci-defaults/luci-ssr-plus
+++ b/luci-app-ssr-plus/root/etc/uci-defaults/luci-ssr-plus
@@ -28,5 +28,10 @@ if [ ! -s "/etc/config/shadowsocksr" ]; then
 fi
 sed -i "s/option type 'vmess'"/"option type 'v2ray'\n\toption v2ray_protocol 'vmess'/g" /etc/config/shadowsocksr
 sed -i "s/option type 'vless'"/"option type 'v2ray'\n\toption v2ray_protocol 'vless'/g" /etc/config/shadowsocksr
+if [ -s "/etc/uwsgi/vassals/luci-webui.ini" ];then
+	limit=$(cat /etc/uwsgi/vassals/luci-webui.ini  | grep -Eo "limit-as.*"|grep -Eo "[0-9]+")
+	[ $limit -lt 5000 ] && sed -i '/limit-as/c\limit-as = 5000' /etc/uwsgi/vassals/luci-webui.ini && \
+	/etc/init.d/uwsgi restart
+fi
 rm -rf /tmp/luci-modulecache /tmp/luci-indexcache
 exit 0


### PR DESCRIPTION
luci-nginx和luci-ssl-nginx使用了uwsgi作为web服务器，uwsgi默认配置中使用`limit-as`限制了虚拟内存的大小为1000m，然而xray申请的虚拟内存为4803m左右，导致在luci中restart或reload shadowsocksr失效。所以修改`limit-as`的值为5000