### PR TITLE
luci-app-ssr-plus: add save checking and filtering for server alias

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/servers.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/servers.lua
@@ -33,6 +33,10 @@ o = s:option(Value, "filter_words", translate("Subscribe Filter Words"))
 o.rmempty = true
 o.description = translate("Filter Words splited by /")
 
+o = s:option(Value, "save_words", translate("Subscribe Save Words"))
+o.rmempty = true
+o.description = translate("Save Words splited by /")
+
 o = s:option(Button, "update_Sub", translate("Update Subscribe List"))
 o.inputstyle = "reload"
 o.description = translate("Update subscribe url list first")

--- a/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
@@ -445,8 +445,14 @@ msgstr "SS/SSR/V2/TROJAN订阅URL"
 msgid "Subscribe Filter Words"
 msgstr "订阅节点关键字过滤"
 
+msgid "Subscribe Save Words"
+msgstr "订阅节点关键字保留检查"
+
 msgid "Filter Words splited by /"
 msgstr "命中关键字的节点将被丢弃。多个关键字用 / 分隔"
+
+msgid "Save Words splited by /"
+msgstr "命中关键字的节点将被保留。多个关键字用 / 分隔。此项为空则不启用保留匹配"
 
 msgid "Update"
 msgstr "更新"

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -906,6 +906,7 @@ reset() {
 		set shadowsocksr.@server_subscribe[0].auto_update_time='2'
 		set shadowsocksr.@server_subscribe[0].auto_update='1'
 		set shadowsocksr.@server_subscribe[0].filter_words='过期时间/剩余流量/QQ群/官网/防失联地址/回国'
+		set shadowsocksr.@server_subscribe[0].save_words=''
 		add shadowsocksr access_control
 		set shadowsocksr.@access_control[0].lan_ac_mode='0'
 		set shadowsocksr.@access_control[0].router_proxy='1'

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -24,6 +24,7 @@ local proxy = ucic:get_first(name, 'server_subscribe', 'proxy', '0')
 local switch = ucic:get_first(name, 'server_subscribe', 'switch', '1')
 local subscribe_url = ucic:get_first(name, 'server_subscribe', 'subscribe_url', {})
 local filter_words = ucic:get_first(name, 'server_subscribe', 'filter_words', '过期时间/剩余流量')
+local save_words = ucic:get_first(name, 'server_subscribe', 'save_words', '')
 local v2_ss = luci.sys.exec('type -t -p ss-redir sslocal') ~= "" and "ss" or "v2ray"
 local v2_tj = luci.sys.exec('type -t -p trojan') ~= "" and "trojan" or "v2ray"
 local log = function(...)
@@ -415,12 +416,42 @@ end
 
 local function check_filer(result)
 	do
+		-- 过滤的关键词列表
 		local filter_word = split(filter_words, "/")
+		-- 保留的关键词列表
+		local check_save = false
+		if save_words ~= nil and save_words ~= "" and save_words ~= "NULL" then
+			check_save = true
+		end
+		local save_word = split(save_words, "/")
+
+		-- 检查结果
+		local filter_result = false
+		local save_result = true
+
+		-- 检查是否存在过滤关键词
 		for i, v in pairs(filter_word) do
 			if result.alias:find(v) then
-				-- log('订阅节点关键字过滤:“' .. v ..'” ，该节点被丢弃')
-				return true
+				filter_result = true
 			end
+		end
+
+		-- 检查是否打开了保留关键词检查，并且进行过滤
+		if check_save == true then
+			for i, v in pairs(save_word) do
+				if result.alias:find(v) then
+					save_result = false
+				end
+			end
+		else
+			save_result = false
+		end
+
+		-- 不等时返回
+		if filter_result == true or save_result == true then
+			return true
+		else
+			return false
 		end
 	end
 end


### PR DESCRIPTION
增加了个节点alias中的关键词保留匹配

* 大概逻辑为
  * 字段为空：不启用这个功能
  * 字段不为空：使用`/`切分关键词，只要存在一个就保留

* 已测试（均符合预期）
  * 为空
  * 一个（没有`/`）
  * 三个

初次写lua，代码不是特别规范aha，但是测试了至少能满足需要了~