### PR TITLE
check DEFAULT_libustream-openssl

### DIFF
--- a/luci-app-ssr-plus/Makefile
+++ b/luci-app-ssr-plus/Makefile
@@ -24,7 +24,8 @@ LUCI_PKGARCH:=all
 LUCI_DEPENDS:=+coreutils +coreutils-base64 +dns2socks +dnsmasq-full +ipset \
 	+ip-full +iptables-mod-tproxy +lua +libuci-lua +microsocks +pdnsd-alt \
 	+tcping +resolveip +shadowsocksr-libev-ssr-check +uclient-fetch \
-	+libustream-openssl \
+	+DEFAULT_libustream-openssl:libustream-openssl \
+	+(!DEFAULT_libustream-openssl):libustream-wolfssl \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun:kcptun-client \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_NaiveProxy:naiveproxy \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Redsocks2:redsocks2 \


### PR DESCRIPTION
[coolsnowwolf/lede](https://github.com/coolsnowwolf/lede/blob/5679a89ee962f20717a2f5e5bc04500cd1323cd4/include/target.mk#L19)与[openwrt/openwrt](https://github.com/openwrt/openwrt/blob/309c8b490241fa4fcef61d2380225be6fde00766/include/target.mk#L20)都使用了`CONFIG_DEFAULT_libustream-*ssl=y`来说明默认使用哪个libustream-ssl库（分别为`libustream-openssl`、`libustream-wolfssl`两个常见的)，所以可以使用`DEFAULT_libustream-openssl`来决定ssr-plus的depends，如果有`CONFIG_DEFAULT_libustream-openssl=y`就使用`libustream-openssl`，否则使用`libustream-wolfssl`