### PR TITLE
remove depend libustream-openssl & add "Include libustream-ssl" to kconfig

### DIFF
--- a/luci-app-ssr-plus/Makefile
+++ b/luci-app-ssr-plus/Makefile
@@ -24,7 +24,6 @@ LUCI_PKGARCH:=all
 LUCI_DEPENDS:=+coreutils +coreutils-base64 +dns2socks +dnsmasq-full +ipset \
 	+ip-full +iptables-mod-tproxy +lua +libuci-lua +microsocks +pdnsd-alt \
 	+tcping +resolveip +shadowsocksr-libev-ssr-check +uclient-fetch \
-	+libustream-openssl \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun:kcptun-client \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_NaiveProxy:naiveproxy \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Redsocks2:redsocks2 \
@@ -44,6 +43,26 @@ LUCI_DEPENDS:=+coreutils +coreutils-base64 +dns2socks +dnsmasq-full +ipset \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Xray:xray-core
 
 define Package/$(PKG_NAME)/config
+menu "Include libustream-ssl"
+	depends on PACKAGE_$(PKG_NAME)
+	config PACKAGE_$(PKG_NAME)_INCLUDE_libustream-wolfssl
+		bool "Include libustream-wolfssl"
+		default y if DEFAULT_libustream-wolfssl
+		select PACKAGE_libustream-wolfssl
+	
+	config PACKAGE_$(PKG_NAME)_INCLUDE_libustream-openssl
+		depends on !PACKAGE_$(PKG_NAME)_INCLUDE_libustream-wolfssl
+		bool "Include libustream-openssl"
+		default y if DEFAULT_libustream-openssl
+		select PACKAGE_libustream-openssl
+
+	config PACKAGE_$(PKG_NAME)_INCLUDE_libustream-mbedtls
+		depends Include !(PACKAGE_$(PKG_NAME)_INCLUDE_libustream-wolfssl || PACKAGE_$(PKG_NAME)_INCLUDE_libustream-openssl)
+		bool "Use libustream-mbedtls"
+		default y if DEFAULT_libustream-mbedtls
+		select PACKAGE_libustream-mbedtls
+
+endmenu
 config PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun
 	bool "Include Kcptun"
 	default n

--- a/v2ray-plugin/Makefile
+++ b/v2ray-plugin/Makefile
@@ -34,6 +34,7 @@ include $(TOPDIR)/feeds/packages/lang/golang/golang-package.mk
 
 define Package/$(PKG_NAME)/config
 config $(PKG_NAME)_INCLUDE_GOPROXY
+	depends on PACKAGE_v2ray-plugin
 	bool "Compiling with GOPROXY proxy"
 	default y
 


### PR DESCRIPTION
移除对libustream-openssl 的依赖。
在kconfig中添加Include libustream-ssl菜单。

不过没有对` libustream-ssl`形成依赖关系，虽然会根据`CONFIG_DEFAULT_libustream_xxxssl=y`默认选择，但是可能会因没有`CONFIG_DEFAULT_libustream_xxxssl=y`或手动取消导致没有编译libustream-ssl。