### PR TITLE
修复make 错误fix config PACKAGE_$(PKG_NAME)_INCLUDE_libustream-mbedtls

### DIFF
--- a/luci-app-ssr-plus/Makefile
+++ b/luci-app-ssr-plus/Makefile
@@ -57,8 +57,8 @@ menu "Include libustream-ssl"
 		select PACKAGE_libustream-openssl
 
 	config PACKAGE_$(PKG_NAME)_INCLUDE_libustream-mbedtls
-		depends Include !(PACKAGE_$(PKG_NAME)_INCLUDE_libustream-wolfssl || PACKAGE_$(PKG_NAME)_INCLUDE_libustream-openssl)
-		bool "Use libustream-mbedtls"
+		depends on !(PACKAGE_$(PKG_NAME)_INCLUDE_libustream-wolfssl || PACKAGE_$(PKG_NAME)_INCLUDE_libustream-openssl)
+		bool "Include libustream-mbedtls"
 		default y if DEFAULT_libustream-mbedtls
 		select PACKAGE_libustream-mbedtls
 


### PR DESCRIPTION
修复`config PACKAGE_$(PKG_NAME)_INCLUDE_libustream-mbedtls`导致的错误。

没有先git commit再做测试，测试完之后，感觉bool "Use libustream-xxx"不太好，改为了"Include libustream-xxx"，结果还改错地方了，又感觉只改了一个标题应该没啥，改完后没做测试。。。 又一次教训😢