### PR TITLE
luci-app-ssr-plus: simplify libustream dependencies

### DIFF
--- a/luci-app-ssr-plus/Makefile
+++ b/luci-app-ssr-plus/Makefile
@@ -21,7 +21,9 @@ PKG_CONFIG_DEPENDS:= \
 
 LUCI_TITLE:=SS/SSR/V2Ray/Trojan/NaiveProxy/Socks5/Tun LuCI interface
 LUCI_PKGARCH:=all
-LUCI_DEPENDS:=+coreutils +coreutils-base64 +dns2socks +dnsmasq-full +ipset \
+LUCI_DEPENDS:= \
+	@(PACKAGE_libustream-mbedtls||PACKAGE_libustream-openssl||PACKAGE_libustream-wolfssl) \
+	+coreutils +coreutils-base64 +dns2socks +dnsmasq-full +ipset \
 	+ip-full +iptables-mod-tproxy +lua +libuci-lua +microsocks +pdnsd-alt \
 	+tcping +resolveip +shadowsocksr-libev-ssr-check +uclient-fetch \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun:kcptun-client \
@@ -43,26 +45,6 @@ LUCI_DEPENDS:=+coreutils +coreutils-base64 +dns2socks +dnsmasq-full +ipset \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Xray:xray-core
 
 define Package/$(PKG_NAME)/config
-menu "Include libustream-ssl"
-	depends on PACKAGE_$(PKG_NAME)
-	config PACKAGE_$(PKG_NAME)_INCLUDE_libustream-wolfssl
-		bool "Include libustream-wolfssl"
-		default y if DEFAULT_libustream-wolfssl
-		select PACKAGE_libustream-wolfssl
-	
-	config PACKAGE_$(PKG_NAME)_INCLUDE_libustream-openssl
-		depends on !PACKAGE_$(PKG_NAME)_INCLUDE_libustream-wolfssl
-		bool "Include libustream-openssl"
-		default y if DEFAULT_libustream-openssl
-		select PACKAGE_libustream-openssl
-
-	config PACKAGE_$(PKG_NAME)_INCLUDE_libustream-mbedtls
-		depends on !(PACKAGE_$(PKG_NAME)_INCLUDE_libustream-wolfssl || PACKAGE_$(PKG_NAME)_INCLUDE_libustream-openssl)
-		bool "Include libustream-mbedtls"
-		default y if DEFAULT_libustream-mbedtls
-		select PACKAGE_libustream-mbedtls
-
-endmenu
 config PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun
 	bool "Include Kcptun"
 	default n


### PR DESCRIPTION
By now, there're 3 variants in libustream, we just need one of them to
work with the SSL support for uclient-fetch.

The old dependencies implementation can cause confusing: users may
select any one of these variants as they don't really know which one
should be used, and when the one they selected differs from default,
the conflict will be up.

As OpenWrt has specified a default variant there already [1][2][3],
we just need check if this library is selected, with whichever variant.
If they really don't wanna use any of them, it's time to say goodbye :D

1. https://github.com/openwrt/openwrt/blob/f85c970c9c91efd74ca11491d28e1f5f24c5bffc/include/target.mk#L20
2. https://github.com/coolsnowwolf/lede/blob/13384d4c5122996327371f7bc446dd2ad25167b0/include/target.mk#L19
3. https://github.com/immortalwrt/immortalwrt/blob/9e56c46a39e1a80930084765aa4b3f9e73686d30/include/target.mk#L20

Signed-off-by: Tianling Shen <cnsztl@immortalwrt.org>