### PR TITLE
Add health check for h2 & gRPC

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -256,6 +256,11 @@ end
 o.rmempty = true
 o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
 
+o = s:option(Flag, "ivCheck", translate("Bloom Filter"))
+o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
+o.default = "1"
+o.rmempty = false
+
 -- Shadowsocks Plugin
 o = s:option(Value, "plugin", translate("Obfs"))
 o:value("none", translate("None"))

--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -383,6 +383,12 @@ o = s:option(Value, "serviceName", translate("serviceName"))
 o:depends("transport", "grpc")
 o.rmempty = true
 
+-- gRPC初始窗口
+o = s:option(Value, "initial_windows_size", translate("Initial Windows Size"))
+o:depends("transport", "grpc")
+o.default = 0
+o.rmempty = true
+
 -- H2/gRPC健康检查
 o = s:option(Flag, "health_check", translate("H2/gRPC Health Check"))
 o:depends("transport", "h2")
@@ -390,12 +396,12 @@ o:depends("transport", "grpc")
 o.rmempty = true
 
 o = s:option(Value, "read_idle_timeout", translate("H2 Read Idle Timeout"))
-o:depends({health_check = 1, transport = "h2"})
+o:depends({health_check = true, transport = "h2"})
 o.default = 60
 o.rmempty = true
 
 o = s:option(Value, "idle_timeout", translate("gRPC Idle Timeout"))
-o:depends({health_check = 1, transport = "grpc"})
+o:depends({health_check = true, transport = "grpc"})
 o.default = 60
 o.rmempty = true
 
@@ -405,7 +411,7 @@ o.default = 20
 o.rmempty = true
 
 o = s:option(Flag, "permit_without_stream", translate("Permit Without Stream"))
-o:depends({health_check = 1, transport = "grpc"})
+o:depends({health_check = true, transport = "grpc"})
 o.rmempty = true
 
 -- [[ QUIC部分 ]]--

--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -383,6 +383,31 @@ o = s:option(Value, "serviceName", translate("serviceName"))
 o:depends("transport", "grpc")
 o.rmempty = true
 
+-- H2/gRPC健康检查
+o = s:option(Flag, "health_check", translate("H2/gRPC Health Check"))
+o:depends("transport", "h2")
+o:depends("transport", "grpc")
+o.rmempty = true
+
+o = s:option(Value, "read_idle_timeout", translate("H2 Read Idle Timeout"))
+o:depends({health_check = 1, transport = "h2"})
+o.default = 60
+o.rmempty = true
+
+o = s:option(Value, "idle_timeout", translate("gRPC Idle Timeout"))
+o:depends({health_check = 1, transport = "grpc"})
+o.default = 60
+o.rmempty = true
+
+o = s:option(Value, "health_check_timeout", translate("Health Check Timeout"))
+o:depends("health_check", 1)
+o.default = 20
+o.rmempty = true
+
+o = s:option(Flag, "permit_without_stream", translate("Permit Without Stream"))
+o:depends({health_check = 1, transport = "grpc"})
+o.rmempty = true
+
 -- [[ QUIC部分 ]]--
 o = s:option(ListValue, "quic_security", translate("QUIC Security"))
 o:depends("transport", "quic")

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -118,7 +118,7 @@ local Xray = {
 		-- 底层传输配置
 		streamSettings = {
 			network = server.transport or "tcp",
-			security = (server.xtls == '1') and "xtls" or (server.tls == '1'or server.transport == "grpc") and "tls" or nil,
+			security = (server.xtls == '1') and "xtls" or (server.tls == '1') and "tls" or nil,
 			tlsSettings = (server.tls == '1' and (server.insecure == "1" or server.tls_host or server.fingerprint)) and {
 				-- tls
 				fingerprint = server.fingerprint,

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -178,7 +178,8 @@ local Xray = {
 				multiMode = (server.mux == "1") and true or false,
 				idle_timeout = tonumber(server.idle_timeout) or nil,
 				health_check_timeout = tonumber(server.health_check_timeout) or nil,
-				permit_without_stream = (server.permit_without_stream == "1") and true or nil
+				permit_without_stream = (server.permit_without_stream == "1") and true or nil,
+				initial_windows_size = tonumber(server.initial_windows_size) or nil
 			} or nil
 		},
 		mux = (server.mux == "1" and server.xtls ~= "1" and server.transport ~= "grpc") and {

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -162,7 +162,9 @@ local Xray = {
 			httpSettings = (server.transport == "h2") and {
 				-- h2
 				path = server.h2_path or "",
-				host = {server.h2_host} or nil
+				host = {server.h2_host} or nil,
+				read_idle_timeout = tonumber(server.read_idle_timeout) or nil,
+				health_check_timeout = tonumber(server.health_check_timeout) or nil
 			} or nil,
 			quicSettings = (server.transport == "quic") and {
 				-- quic
@@ -173,7 +175,10 @@ local Xray = {
 			grpcSettings = (server.transport == "grpc") and {
 				-- grpc
 				serviceName = server.serviceName or "",
-				multiMode = (server.mux == "1") and true or false
+				multiMode = (server.mux == "1") and true or false,
+				idle_timeout = tonumber(server.idle_timeout) or nil,
+				health_check_timeout = tonumber(server.health_check_timeout) or nil,
+				permit_without_stream = (server.permit_without_stream == "1") and true or nil
 			} or nil
 		},
 		mux = (server.mux == "1" and server.xtls ~= "1" and server.transport ~= "grpc") and {

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -33,7 +33,8 @@ function trojan_shadowsocks()
 				port = tonumber(server.server_port),
 				password = server.password,
 				method = (server.v2ray_protocol == "shadowsocks") and server.encrypt_method_v2ray_ss or nil,
-				flow = (server.v2ray_protocol == "trojan") and (server.xtls == '1') and (server.vless_flow and server.vless_flow or "xtls-rprx-splice") or nil
+				flow = (server.v2ray_protocol == "trojan") and (server.xtls == '1') and (server.vless_flow and server.vless_flow or "xtls-rprx-splice") or nil,
+				ivCheck = (server.v2ray_protocol == "shadowsocks") and (server.ivCheck == '1') or nil
 			}
 		}
 	}


### PR DESCRIPTION
草，后面的两个commit怎么也被自动合并进来了😂算了 那就一块吧

1，支持 Xray-core 的 H2/gRPC 健康检查功能，详见[此处](https://github.com/XTLS/Xray-core/pull/633#issuecomment-878989087)

2，新增选项，用于调整 **initial_windows_size** 。这个参数可以帮助解决gRPC在通过CloudFlare时出现的断流问题，具体的说明见[文档](https://github.com/XTLS/Xray-docs-next/blob/130ad7437dc0dcf57f0b23825e15ef00f18b2b8b/docs/config/transports/grpc.md#grpcobject)。对应 Xray-core 的commit在 [这里](https://github.com/XTLS/Xray-core/commit/63da3a548138640f96e631f10d6e2ee1bae3ed62)

3，新增选框 Bloom Filter，以支持 Xray-core v1.5.1 中的 Shadowsocks 安全增强功能，可能对防范重放攻击[有所帮助](https://github.com/XTLS/Xray-core/issues/625#issuecomment-962390112)。实际测试下，这个功能在服务端/客户端单边启用不会导致 '明显的' 兼容性问题，所以我将它默认设置为开；更多说明请见[Xray的releases页面](https://github.com/XTLS/Xray-core/releases/tag/v1.5.1)

4，这个算是我夹带的私货了 XD 。我昨天在尝试部署基于明文gRPC的代理服务（也就是h2c协议，走的是80端口）。同样的设置，其他设备都能正常使用，唯独SSR+插件用不了。阅读了 gen_config.lua 之后我才发现，gRPC 和 TLS 被绑定在了一起，后者被自动启用，导致了连接失败。我认为去除这一句判断对普通用户的影响不大，保留它反而是替用户做决定，影响到了某些正常的功能，所以就顺便去掉了 T^T