### PR TITLE
Add the device attribute of getting  interface

### DIFF
--- a/luci-app-ssr-plus/root/usr/bin/ssr-rules
+++ b/luci-app-ssr-plus/root/usr/bin/ssr-rules
@@ -191,6 +191,7 @@ ac_rule() {
 	else
 		for name in $Interface; do
 			local IFNAME=$(uci -P /var/state get network.$name.ifname 2>/dev/null)
+			[ -z "$IFNAME" ] && IFNAME=$(uci -P /var/state get network.$name.device 2>/dev/null)
 			[ -n "$IFNAME" ] && $IPT -I PREROUTING 1 ${IFNAME:+-i $IFNAME} -p tcp $EXT_ARGS $MATCH_SET -m comment --comment "$TAG" -j SS_SPEC_WAN_AC
 		done
 	fi
@@ -262,6 +263,7 @@ tp_rule() {
 	else
 		for name in $Interface; do
 			local IFNAME=$(uci -P /var/state get network.$name.ifname 2>/dev/null)
+			[ -z "$IFNAME" ] && IFNAME=$(uci -P /var/state get network.$name.device 2>/dev/null)
 			[ -n "$IFNAME" ] && $ipt -I PREROUTING 1 ${IFNAME:+-i $IFNAME} -p udp $EXT_ARGS $MATCH_SET -m comment --comment "$TAG" -j SS_SPEC_TPROXY
 		done
 	fi


### PR DESCRIPTION
Openwrt使用`device`取代了`ifname`，虽然为了兼容，Openwrt会在路由器开机时为lan、wan等接口生成`ifname`属性，但是因为脚本顺序问题，可能出现 “在ssr启动后才生成`ifname`” 的情况。