### PR TITLE
Change trojan subscribe logic to allow insecure

### DIFF
--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -326,7 +326,7 @@ local function processData(szType, content)
 		result.v2ray_protocol = "trojan"
 		result.server = host[1]
 		-- 按照官方的建议 默认验证ssl证书
-		result.insecure = "0"
+		result.insecure = "1"
 		result.tls = "1"
 		if host[2]:find("?") then
 			local query = split(host[2], "?")


### PR DESCRIPTION
Change trojan subscribe logic to allow insecure connection.

Hi, 

目前订阅trojan连接需要手动指定每个节点的“允许不安全连接”选项为真，希望能够兼容一下，谢谢🙏！