### PR TITLE
fix gfwlist and nfip_url

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
@@ -45,11 +45,10 @@ o:depends("enable_switch", "1")
 o.default = 3
 
 o = s:option(Value, "gfwlist_url", translate("gfwlist Update url"))
-o:value("https://cdn.jsdelivr.net/gh/YW5vbnltb3Vz/domain-list-community@release/gfwlist.txt", translate("v2fly/domain-list-community"))
-o:value("https://cdn.jsdelivr.net/gh/Loyalsoldier/v2ray-rules-dat@release/gfw.txt", translate("Loyalsoldier/v2ray-rules-dat"))
-o:value("https://cdn.jsdelivr.net/gh/Loukky/gfwlist-by-loukky/gfwlist.txt", translate("Loukky/gfwlist-by-loukky"))
-o:value("https://cdn.jsdelivr.net/gh/gfwlist/gfwlist/gfwlist.txt", translate("gfwlist/gfwlist"))
-o.default = "https://cdn.jsdelivr.net/gh/YW5vbnltb3Vz/domain-list-community@release/gfwlist.txt"
+o:value("https://raw.githubusercontent.com/Loyalsoldier/v2ray-rules-dat/release/gfw.txt", translate("Loyalsoldier/v2ray-rules-dat"))
+o:value("https://raw.githubusercontent.com/Loukky/gfwlist-by-loukky/master/gfwlist.txt", translate("Loukky/gfwlist-by-loukky"))
+o:value("https://raw.githubusercontent.com/gfwlist/gfwlist/master/gfwlist.txt", translate("gfwlist/gfwlist"))
+o.default = "https://raw.githubusercontent.com/Loyalsoldier/v2ray-rules-dat/release/gfw.txt"
 
 o = s:option(Value, "chnroute_url", translate("Chnroute Update url"))
 o:value("https://ispip.clang.cn/all_cn.txt", translate("Clang.CN"))
@@ -60,9 +59,9 @@ o = s:option(Flag, "netflix_enable", translate("Enable Netflix Mode"))
 o.rmempty = false
 
 o = s:option(Value, "nfip_url", translate("nfip_url"))
-o:value("https://cdn.jsdelivr.net/gh/QiuSimons/Netflix_IP/NF_only.txt", translate("Netflix IP Only"))
-o:value("https://cdn.jsdelivr.net/gh/QiuSimons/Netflix_IP/getflix.txt", translate("Netflix and AWS"))
-o.default = "https://cdn.jsdelivr.net/gh/QiuSimons/Netflix_IP/NF_only.txt"
+o:value("https://raw.githubusercontent.com/QiuSimons/Netflix_IP/master/NF_only.txt", translate("Netflix IP Only"))
+o:value("https://raw.githubusercontent.com/QiuSimons/Netflix_IP/master/getflix.txt", translate("Netflix and AWS"))
+o.default = "https://raw.githubusercontent.com/QiuSimons/Netflix_IP/master/NF_only.txt"
 o.description = translate("Customize Netflix IP Url")
 o:depends("netflix_enable", "1")
 


### PR DESCRIPTION
v2fly/domain-list-community 已移除 gfwlist 生成。
https://github.com/v2fly/domain-list-community/issues/322

jsdelivr.net 最近经常处于不可用状态。
https://v2ex.com/t/849943