### PR TITLE
Remove duplicate AEAD ciphers and add shadowsocks-2022 ciphers.

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -74,13 +74,11 @@ local encrypt_methods_v2ray_ss = {
 	-- aead
 	"aes-128-gcm",
 	"aes-256-gcm",
-	"chacha20-poly1305",
 	"chacha20-ietf-poly1305",
 	"xchacha20-ietf-poly1305",
-	"aead_aes_128_gcm",
-	"aead_aes_256_gcm",
-	"aead_chacha20_poly1305",
-	"aead_xchacha20_poly1305"
+	"2022-blake3-aes-128-gcm",
+	"2022-blake3-aes-256-gcm",
+	"2022-blake3-chacha20-poly1305"
 }
 
 local protocol = {


### PR DESCRIPTION
Xray (version>=1.5.6) has made shadowsocks-2022 ciphers available.