### PR TITLE
兼容 allowInsecure

### DIFF
--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -329,8 +329,6 @@ local function processData(szType, content)
 		result.type = v2_tj
 		result.v2ray_protocol = "trojan"
 		result.server = host[1]
-		-- 按照官方的建议 默认验证ssl证书
-		result.insecure = "0"
 		result.tls = "1"
 		if host[2]:find("?") then
 			local query = split(host[2], "?")
@@ -340,6 +338,8 @@ local function processData(szType, content)
 				local t = split(v, '=')
 				params[t[1]] = t[2]
 			end
+			-- 按照官方的建议 默认验证ssl证书 兼容不验证参数
+			result.insecure = params.allowInsecure or "0"
 			if params.sni then
 				-- 未指定peer（sni）默认使用remote addr
 				result.tls_host = params.sni


### PR DESCRIPTION
很多机场为了混淆成大厂的host，比如sni是抖音、快手的cdn域名，证书的host就匹配不上了。
这种情况也拜托兼容一下吧，如果url里指定了 allowInsecure 参数就允许。