### PR TITLE
luci-app-ssr-plus: ws: add enable early data option

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -431,16 +431,20 @@ o:depends("transport", "ws")
 o.rmempty = true
 
 if is_finded("v2ray") then
+	-- 启用WS前置数据
+	o = s:option(Flag, "ws_ed_enable", translate("Enable early data"))
+	o:depends("transport", "ws")
+
 	-- WS前置数据
 	o = s:option(Value, "ws_ed", translate("Max Early Data"))
-	o:depends("transport", "ws")
+	o:depends("ws_ed_enable", true)
 	o.datatype = "uinteger"
 	o.default = 2048
 	o.rmempty = true
 
 	-- WS前置数据标头
 	o = s:option(Value, "ws_ed_header", translate("Early Data Header Name"))
-	o:depends("transport", "ws")
+	o:depends("ws_ed_enable", true)
 	o.default = "Sec-WebSocket-Protocol"
 	o.rmempty = true
 end

--- a/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
@@ -727,6 +727,9 @@ msgstr "WebSocket 主机名"
 msgid "WebSocket Path"
 msgstr "WebSocket 路径"
 
+msgid "Enable early data"
+msgstr "启用前置数据"
+
 msgid "Max Early Data"
 msgstr "最大前置数据"
 


### PR DESCRIPTION
对于没有设置 maxEarlyData、earlyDataHeaderName ws 参数的 v2ray 服务端，ssrp 默认添加前置数据会导致节点无法连接，添加选项按需启用打破这种尴尬