### PR TITLE
luci: cleanup makefile

### DIFF
--- a/luci-app-ssr-plus/Makefile
+++ b/luci-app-ssr-plus/Makefile
@@ -32,127 +32,129 @@ LUCI_DEPENDS:= \
 	@(PACKAGE_libustream-mbedtls||PACKAGE_libustream-openssl||PACKAGE_libustream-wolfssl) \
 	+coreutils +coreutils-base64 +dns2socks +dns2tcp +dnsmasq-full +ipset +kmod-ipt-nat \
 	+ip-full +iptables +iptables-mod-tproxy +lua +lua-neturl +libuci-lua +microsocks \
-	+tcping +resolveip +shadowsocksr-libev-ssr-check +uclient-fetch \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_V2ray:curl \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_V2ray:v2ray-core \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Xray:curl \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Xray:xray-core \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_SagerNet_Core:curl \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_SagerNet_Core:sagernet-core \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun:kcptun-client \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria:hysteria \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_IPT2Socks:ipt2socks \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_NaiveProxy:naiveproxy \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Redsocks2:redsocks2 \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Client:shadowsocks-libev-ss-local \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Client:shadowsocks-libev-ss-redir \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Server:shadowsocks-libev-ss-server \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Client:shadowsocks-rust-sslocal \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Server:shadowsocks-rust-ssserver \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Simple_Obfs:simple-obfs \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_V2ray_Plugin:v2ray-plugin \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Client:shadowsocksr-libev-ssr-local \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Client:shadowsocksr-libev-ssr-redir \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server:shadowsocksr-libev-ssr-server \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Trojan:trojan
+	+tcping +resolveip +shadowsocksr-libev-ssr-check +uclient-fetch
 
 define Package/$(PKG_NAME)/config
-select PACKAGE_luci-lib-ipkg if PACKAGE_$(PKG_NAME)
+	if PACKAGE_$(PKG_NAME)
+		select PACKAGE_luci-lib-ipkg
 
-choice
-	prompt "Shadowsocks Client Selection"
-	default PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Client if aarch64
-	default PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Client
+		choice
+			prompt "Shadowsocks Client Selection"
+			default PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Client if aarch64
+			default PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Client
 
-	config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_NONE_Client
-	bool "None"
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_NONE_Client
+			bool "None"
 
-	config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Client
-	bool "Shadowsocks-libev"
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Client
+			bool "Shadowsocks-libev"
+			select PACKAGE_shadowsocks-libev-ss-local
+			select PACKAGE_shadowsocks-libev-ss-redir
 
-	config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Client
-	bool "Shadowsocks-rust"
-	depends on aarch64||arm||i386||mips||mipsel||x86_64
-	depends on !(TARGET_x86_geode||TARGET_x86_legacy)
-endchoice
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Client
+			bool "Shadowsocks-rust"
+			depends on aarch64||arm||i386||mips||mipsel||x86_64
+			depends on !(TARGET_x86_geode||TARGET_x86_legacy)
+			select PACKAGE_shadowsocks-rust-sslocal
+		endchoice
 
-choice
-	prompt "Shadowsocks Server Selection"
-	default PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Server if aarch64
-	default PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Server if i386||x86_64||arm
-	default PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_NONE_Server
+		choice
+			prompt "Shadowsocks Server Selection"
+			default PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Server if aarch64
+			default PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Server if i386||x86_64||arm
+			default PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_NONE_Server
 
-	config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_NONE_Server
-	bool "None"
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_NONE_Server
+			bool "None"
 
-	config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Server
-	bool "Shadowsocks-libev"
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Server
+			bool "Shadowsocks-libev"
+			select PACKAGE_shadowsocks-libev-ss-server
 
-	config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Server
-	bool "Shadowsocks-rust"
-	depends on aarch64||arm||i386||mips||mipsel||x86_64
-	depends on !(TARGET_x86_geode||TARGET_x86_legacy)
-endchoice
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Rust_Server
+			bool "Shadowsocks-rust"
+			depends on aarch64||arm||i386||mips||mipsel||x86_64
+			depends on !(TARGET_x86_geode||TARGET_x86_legacy)
+			select PACKAGE_shadowsocks-rust-ssserver
+		endchoice
 
-choice
-	prompt "V2ray-core Selection"
-	default PACKAGE_$(PKG_NAME)_INCLUDE_Xray if aarch64||arm||i386||x86_64
-	default PACKAGE_$(PKG_NAME)_INCLUDE_NONE_V2RAY
+		choice
+			prompt "V2ray-core Selection"
+			default PACKAGE_$(PKG_NAME)_INCLUDE_Xray if aarch64||arm||i386||x86_64
+			default PACKAGE_$(PKG_NAME)_INCLUDE_NONE_V2RAY
 
-	config PACKAGE_$(PKG_NAME)_INCLUDE_NONE_V2RAY
-	bool "None"
+			config PACKAGE_$(PKG_NAME)_INCLUDE_NONE_V2RAY
+			bool "None"
 
-	config PACKAGE_$(PKG_NAME)_INCLUDE_V2ray
-	bool "V2ray-core"
+			config PACKAGE_$(PKG_NAME)_INCLUDE_V2ray
+			bool "V2ray-core"
+			select PACKAGE_curl
+			select PACKAGE_v2ray-core
 
-	config PACKAGE_$(PKG_NAME)_INCLUDE_Xray
-	bool "Xray-core"
+			config PACKAGE_$(PKG_NAME)_INCLUDE_Xray
+			bool "Xray-core"
+			select PACKAGE_curl
+			select PACKAGE_xray-core
 
-	config PACKAGE_$(PKG_NAME)_INCLUDE_SagerNet_Core
-	bool "SagerNet-core (An enhanced edition of v2ray-core)"
-endchoice
+			config PACKAGE_$(PKG_NAME)_INCLUDE_SagerNet_Core
+			bool "SagerNet-core (An enhanced edition of v2ray-core)"
+			select PACKAGE_curl
+			select PACKAGE_sagernet-core
+		endchoice
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun
-	bool "Include Kcptun"
-	default n
+		config PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun
+			bool "Include Kcptun"
+			select PACKAGE_kcptun-client
+			default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria
-	bool "Include Hysteria"
-	default n
+		config PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria
+			bool "Include Hysteria"
+			select PACKAGE_hysteria
+			default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_IPT2Socks
-	bool "Include IPT2Socks"
-	default n
+		config PACKAGE_$(PKG_NAME)_INCLUDE_IPT2Socks
+			bool "Include IPT2Socks"
+			select PACKAGE_ipt2socks
+			default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_NaiveProxy
-	bool "Include NaiveProxy"
-	depends on !(arc||armeb||mips||mips64||powerpc||TARGET_gemini)
-	default n
+		config PACKAGE_$(PKG_NAME)_INCLUDE_NaiveProxy
+			bool "Include NaiveProxy"
+			depends on !(arc||armeb||mips||mips64||powerpc||TARGET_gemini)
+			select PACKAGE_naiveproxy
+			default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Redsocks2
-	bool "Include Redsocks2"
-	default n
+		config PACKAGE_$(PKG_NAME)_INCLUDE_Redsocks2
+			bool "Include Redsocks2"
+			select PACKAGE_redsocks2
+			default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Simple_Obfs
-	bool "Include Shadowsocks Simple Obfs Plugin"
-	default y
+		config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Simple_Obfs
+			bool "Include Shadowsocks Simple Obfs Plugin"
+			select PACKAGE_simple-obfs
+			default y
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_V2ray_Plugin
-	bool "Include Shadowsocks V2ray Plugin"
-	default n
+		config PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_V2ray_Plugin
+			bool "Include Shadowsocks V2ray Plugin"
+			select PACKAGE_v2ray-plugin
+			default n
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Client
-	bool "Include ShadowsocksR Libev Client"
-	default y
+		config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Client
+			bool "Include ShadowsocksR Libev Client"
+			select PACKAGE_shadowsocksr-libev-ssr-local
+			select PACKAGE_shadowsocksr-libev-ssr-redir
+			default y
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server
-	bool "Include ShadowsocksR Libev Server"
-	default y if i386||x86_64||arm
+		config PACKAGE_$(PKG_NAME)_INCLUDE_ShadowsocksR_Libev_Server
+			bool "Include ShadowsocksR Libev Server"
+			select PACKAGE_shadowsocksr-libev-ssr-server
+			default y if i386||x86_64||arm
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Trojan
-	bool "Include Trojan"
-	select PACKAGE_$(PKG_NAME)_INCLUDE_IPT2Socks
-	default n
+		config PACKAGE_$(PKG_NAME)_INCLUDE_Trojan
+			bool "Include Trojan"
+			select PACKAGE_$(PKG_NAME)_INCLUDE_IPT2Socks
+			select PACKAGE_trojan
+			default n
+	endif
 endef
 
 define Package/$(PKG_NAME)/conffiles


### PR DESCRIPTION
因为Makefile中的`define Package/$(PKG_NAME)/config`部分没有加条件判断，对部分`PACKAGE_$(PKG_NAME)_INCLUDE_xxx`类包设置了`default y`，使得编译openwrt时即使不选择luci-app-ssr-plus，部分`PACKAGE_$(PKG_NAME)_INCLUDE_xxx`也会被默认选中。例如对x64设备，即使不选中luci-app-ssr-plus，simple-obfs、xray-core等组件也会因luci-app-ssr-plus的Makefile而被默认编译上。

这一PR使`luci-app-ssr-plus_INCLUDE_xxx`类包只有在luci-app-ssr-plus被选中后才能被配置，不选择luci-app-ssr-plus则不会被默认安装，选中luci-app-ssr-plus后仍能默认安装simple-obfs、xray-core等组件。

我已在passwall的repo中提交了类似PR xiaorouji/openwrt-passwall#2118