### PR TITLE
luci-app-ssr-plus: add chinadns-ng support

### DIFF
--- a/chinadns-ng/Makefile
+++ b/chinadns-ng/Makefile
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: GPL-3.0-only
+#
+# Copyright (C) 2021 ImmortalWrt.org
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=chinadns-ng
+PKG_VERSION:=1.0-beta.25
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/zfl9/chinadns-ng.git
+PKG_SOURCE_DATE:=2021-05-08
+PKG_SOURCE_VERSION:=14cc6348d67b09cae37d9bce554c89c2c0e0b265
+PKG_MIRROR_HASH:=3b66fc0888d9488e3b8e39df3016d51fae1b43325d292381e94aa3c7d2318282
+
+PKG_LICENSE:=AGPL-3.0-only
+PKG_LICENSE_FILES:=LICENSE
+PKG_MAINTAINER:=pexcn <i@pexcn.me>
+
+PKG_BUILD_PARALLEL:=1
+PKG_INSTALL:=1
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/chinadns-ng
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=IP Addresses and Names
+  TITLE:=ChinaDNS next generation, refactoring with epoll and ipset.
+  URL:=https://github.com/zfl9/chinadns-ng
+  DEPENDS:=+ipset
+endef
+
+define Package/chinadns-ng/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/chinadns-ng $(1)/usr/bin
+endef
+
+$(eval $(call BuildPackage,chinadns-ng))

--- a/luci-app-ssr-plus/Makefile
+++ b/luci-app-ssr-plus/Makefile
@@ -2,16 +2,17 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ssr-plus
 PKG_VERSION:=186
-PKG_RELEASE:=6
+PKG_RELEASE:=7
 
 PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_NONE_V2RAY \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_V2ray \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_Xray \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_SagerNet_Core \
-	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun \
+	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_ChinaDNS_NG \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_IPT2Socks \
+	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_NaiveProxy \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_Redsocks2 \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_NONE_Client \
@@ -39,9 +40,10 @@ LUCI_DEPENDS:= \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Xray:xray-core \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_SagerNet_Core:curl \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_SagerNet_Core:sagernet-core \
-	+PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun:kcptun-client \
+	+PACKAGE_$(PKG_NAME)_INCLUDE_ChinaDNS_NG:chinadns-ng \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria:hysteria \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_IPT2Socks:ipt2socks \
+	+PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun:kcptun-client \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_NaiveProxy:naiveproxy \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Redsocks2:redsocks2 \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Shadowsocks_Libev_Client:shadowsocks-libev-ss-local \
@@ -112,9 +114,9 @@ choice
 	bool "SagerNet-core (An enhanced edition of v2ray-core)"
 endchoice
 
-config PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun
-	bool "Include Kcptun"
-	default n
+config PACKAGE_$(PKG_NAME)_INCLUDE_ChinaDNS_NG
+	bool "Include ChinaDNS-NG"
+	default y
 
 config PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria
 	bool "Include Hysteria"
@@ -122,6 +124,10 @@ config PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria
 
 config PACKAGE_$(PKG_NAME)_INCLUDE_IPT2Socks
 	bool "Include IPT2Socks"
+	default n
+
+config PACKAGE_$(PKG_NAME)_INCLUDE_Kcptun
+	bool "Include Kcptun"
 	default n
 
 config PACKAGE_$(PKG_NAME)_INCLUDE_NaiveProxy

--- a/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
@@ -457,6 +457,18 @@ msgstr "使用 DNS2SOCKS 查询并缓存"
 msgid "DNS Server IP:Port"
 msgstr "DNS服务器 IP:Port"
 
+msgid "Domestic DNS Server"
+msgstr "国内DNS服务器"
+
+msgid "Use DNS from WAN"
+msgstr "使用WAN下发的DNS"
+
+msgid "Use DNS from WAN and 114DNS"
+msgstr "使用WAN下发的DNS和114DNS"
+
+msgid "Custom DNS Server format as IP:PORT (default: disabled)"
+msgstr "格式为 IP:PORT (默认: 禁用)"
+
 msgid "Update time (every day)"
 msgstr "更新时间 (每天)"
 

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -26,6 +26,7 @@ shunt_dns_config_file=
 tmp_local_port=
 ARG_UDP=
 dns_port="5335"            #dns port
+china_dns_port="5333"      #china_dns_port
 tmp_dns_port="300"         #dns2socks temporary port
 tmp_udp_port="301"         #udp temporary port
 tmp_udp_local_port="302"   #udp socks temporary port
@@ -165,27 +166,45 @@ ln_start_bin() {
 
 start_dns() {
 	local ssrplus_dns="$(uci_get_by_type global pdnsd_enable 0)"
-	local dnsstr="$(uci_get_by_type global tunnel_forward 8.8.4.4:53)"
-	local dnsserver=$(echo "$dnsstr" | awk -F ':' '{print $1}')
-	local dnsport=$(echo "$dnsstr" | awk -F ':' '{print $2}')
+	local dnsserver="$(uci_get_by_type global tunnel_forward 8.8.4.4:53)"
+	local run_mode="$(uci_get_by_type global run_mode)"
 
 	if [ "$ssrplus_dns" != "0" ]; then
-		case "$(uci_get_by_type global run_mode)" in
-		gfw) ipset add gfwlist $dnsserver 2>/dev/null ;;
-		oversea) ipset add oversea $dnsserver 2>/dev/null ;;
-		*) ipset add ss_spec_wan_ac $dnsserver nomatch 2>/dev/null ;;
+		case "$run_mode" in
+		gfw) ipset add gfwlist ${dnsserver%:*} 2>/dev/null ;;
+		oversea) ipset add oversea ${dnsserver%:*} 2>/dev/null ;;
+		*) ipset add ss_spec_wan_ac ${dnsserver%:*} nomatch 2>/dev/null ;;
 		esac
 		case "$ssrplus_dns" in
 		1)
-			ln_start_bin $(first_type dns2tcp) dns2tcp -L "127.0.0.1#$dns_port" -R "$dnsserver#$dnsport"
+			ln_start_bin $(first_type dns2tcp) dns2tcp -L 127.0.0.1#$dns_port -R ${dnsserver/:/#}
 			pdnsd_enable_flag=1
 			;;
 		2)
 			ln_start_bin $(first_type microsocks) microsocks -i 127.0.0.1 -p $tmp_dns_port ssrplus-dns
-			ln_start_bin $(first_type dns2socks) dns2socks 127.0.0.1:$tmp_dns_port $dnsserver:$dnsport 127.0.0.1:$dns_port -q
+			ln_start_bin $(first_type dns2socks) dns2socks 127.0.0.1:$tmp_dns_port $dnsserver 127.0.0.1:$dns_port -q
 			pdnsd_enable_flag=2
 			;;
 		esac
+		if [ "$run_mode" = "router" ]; then
+			local chinadns="$(uci_get_by_type global chinadns_forward)"
+			if [ -n "$chinadns" ]; then
+				local wandns="$(ifstatus wan | jsonfilter -e '@["dns-server"][0]' || echo "119.29.29.29")"
+				case "$chinadns" in
+				"wan") chinadns="$wandns" ;;
+				"wan_114") chinadns="$wandns,114.114.114.114" ;;
+				esac
+
+				ln_start_bin $(first_type chinadns-ng) chinadns-ng -l $china_dns_port -4 china -p 3 -c ${chinadns/:/#} -t 127.0.0.1#$dns_port -N -f -r
+
+				uci -q rename "dhcp.@dnsmasq[0].noresolv"="_orig_noresolv"
+				uci -q rename "dhcp.@dnsmasq[0].server"="_orig_server"
+				uci -q set "dhcp.@dnsmasq[0].noresolv"="1"
+				uci -q add_list "dhcp.@dnsmasq[0].server"="127.0.0.1#$china_dns_port"
+				uci -q set "dhcp.@dnsmasq[0]._unused_ssrp_changed"=1
+				uci -q commit "dhcp"
+			fi
+		fi
 	fi
 }
 
@@ -871,6 +890,15 @@ stop() {
 	$PS -w | grep -v "grep" | grep "$TMP_PATH" | awk '{print $1}' | xargs kill -9 >/dev/null 2>&1 &
 	killall -q -9 v2ray-plugin obfs-local xray-plugin
 	rm -f /var/lock/ssr-monitor.lock
+	if [ "$(uci -q get "dhcp.@dnsmasq[0]._unused_ssrp_changed")" = "1" ]; then
+		uci -q del "dhcp.@dnsmasq[0].noresolv"
+		uci -q del_list "dhcp.@dnsmasq[0].server"="127.0.0.1#$china_dns_port"
+		uci -q rename "dhcp.@dnsmasq[0]._orig_noresolv"="noresolv"
+		uci -q rename "dhcp.@dnsmasq[0]._orig_server"="server"
+		uci -q del "dhcp.@dnsmasq[0]._unused_ssrp_changed"
+		uci -q commit "dhcp"
+		killall -9 chinadns-ng
+	fi
 	if [ -f "/tmp/dnsmasq.d/dnsmasq-ssrplus.conf" ]; then
 		rm -rf /tmp/dnsmasq.d/dnsmasq-ssrplus.conf $TMP_DNSMASQ_PATH $TMP_PATH/*-ssr-*.json $TMP_PATH/ssr-server*.json
 		/etc/init.d/dnsmasq restart >/dev/null 2>&1

--- a/luci-app-ssr-plus/root/usr/bin/ssr-monitor
+++ b/luci-app-ssr-plus/root/usr/bin/ssr-monitor
@@ -88,25 +88,37 @@ while [ "1" == "1" ]; do #死循环
 		if [ "$icount" -lt 1 ]; then #如果进程挂掉就重启它
 			logger -t "$NAME" "dns2tcp tunnel error.restart!"
 			echolog "dns2tcp tunnel error.restart!"
-			dnsstr=$(uci_get_by_type global tunnel_forward 8.8.4.4:53)
-			dnsserver=$(echo "$dnsstr" | awk -F ':' '{print $1}')
-			dnsport=$(echo "$dnsstr" | awk -F ':' '{print $2}')
+			dnsserver=$(uci_get_by_type global tunnel_forward 8.8.4.4:53)
 			kill -9 $(busybox ps -w | grep $TMP_BIN_PATH/dns2tcp | grep -v grep | awk '{print $1}') >/dev/null 2>&1
-			ln_start_bin $(first_type dns2tcp) dns2tcp -L "127.0.0.1#$dns_port" -R "$dnsserver#$dnsport"
+			ln_start_bin $(first_type dns2tcp) dns2tcp -L "127.0.0.1#$dns_port" -R "${dnsserver/:/#}"
 		fi
 	#dns2socks
 	elif [ "$pdnsd_process" -eq 2 ]; then
 		icount=$(busybox ps -w | grep -e ssrplus-dns -e "dns2socks 127.0.0.1 $tmp_dns_port" | grep -v grep | wc -l)
 		if [ "$icount" -lt 2 ]; then #如果进程挂掉就重启它
-			logger -t "$NAME" "dns2socks $dnsstr tunnel error.restart!"
-			echolog "dns2socks $dnsstr tunnel error.restart!"
-			dnsstr=$(uci_get_by_type global tunnel_forward 8.8.4.4:53)
-			dnsserver=$(echo "$dnsstr" | awk -F ':' '{print $1}')
-			dnsport=$(echo "$dnsstr" | awk -F ':' '{print $2}')
+			logger -t "$NAME" "dns2socks $dnsserver tunnel error.restart!"
+			echolog "dns2socks $dnsserver tunnel error.restart!"
+			dnsserver=$(uci_get_by_type global tunnel_forward 8.8.4.4:53)
 			kill -9 $(busybox ps -w | grep ssrplus-dns | grep -v grep | awk '{print $1}') >/dev/null 2>&1
 			kill -9 $(busybox ps -w | grep "dns2socks 127.0.0.1 $tmp_dns_port" | grep -v grep | awk '{print $1}') >/dev/null 2>&1
 			ln_start_bin $(first_type microsocks) microsocks -i 127.0.0.1 -p $tmp_dns_port ssrplus-dns
-			ln_start_bin $(first_type dns2socks) dns2socks 127.0.0.1:$tmp_dns_port $dnsserver:$dnsport 127.0.0.1:$dns_port -q
+			ln_start_bin $(first_type dns2socks) dns2socks 127.0.0.1:$tmp_dns_port $dnsserver 127.0.0.1:$dns_port -q
+		fi
+	fi
+	#chinadns-ng
+	if [ "$(uci -q get "dhcp.@dnsmasq[0]._unused_ssrp_changed")" = "1" ]; then
+		icount=$(busybox ps -w | grep $TMP_BIN_PATH/chinadns-ng | grep -v grep | wc -l)
+		if [ "$icount" -lt 1 ]; then #如果进程挂掉就重启它
+			logger -t "$NAME" "chinadns-ng tunnel error.restart!"
+			echolog "chinadns-ng tunnel error.restart!"
+			chinadns=$(uci_get_by_type global chinadns_forward)
+			wandns="$(ifstatus wan | jsonfilter -e '@["dns-server"][0]' || echo "119.29.29.29")"
+			case "$chinadns" in
+			"wan") chinadns="$wandns" ;;
+			""|"wan_114") chinadns="$wandns,114.114.114.114" ;;
+			esac
+			kill -9 $(busybox ps -w | grep $TMP_BIN_PATH/chinadns-ng | grep -v grep | awk '{print $1}') >/dev/null 2>&1
+			ln_start_bin $(first_type chinadns-ng) chinadns-ng -l $china_dns_port -4 china -p 3 -c ${chinadns/:/#} -t 127.0.0.1#$dns_port -N -f -r
 		fi
 	fi
 done


### PR DESCRIPTION
ChinaDNS-NG 是一个解决 DNS 污染的轻量级方案。

如今 DNS 污染日益严重，GFWList 内置的域名已然更不上 GFW 的更新，目前仅 v2ray / xray 和 ssr 支持域名嗅探，并且存在国内 DNS 返回保留地址的问题。

引入 ChinaDNS-NG 可以极大程度上缓解该问题，但由于所有请求均会先往国内 DNS 发送（GFWList 中的域名除外），故存在所谓“DNS 泄露”，由用户自行决定是否使用。