### PR TITLE
luci-app-ssr-plus: support Hysteria port hopping

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -211,7 +211,6 @@ o:depends("type", "hysteria")
 o:depends("type", "socks5")
 
 o = s:option(Value, "server_port", translate("Server Port"))
-o.datatype = "port"
 o.rmempty = false
 o:depends("type", "ssr")
 o:depends("type", "ss")


### PR DESCRIPTION
Starting with 1.3.0, Hysteria has support for multi-port addresses on the client side. Format:

server:port1,port2-port3,...
Examples:

example.com:1145,5144 means that the server is available on ports 1145 and 5144 (2 ports in total)

example.com:20000-50000 means that the server is available on ports 20000-50000 (30001 ports in total)

example.com:1145,5144-10240 means the server is available on ports 1145 and 5144-10240 (5098 ports in total)