### PR TITLE
luci-app-ssr-plus: support Hysteria Fast Open

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -772,6 +772,7 @@ o.default = "0"
 o:depends("type", "ssr")
 o:depends("type", "ss")
 o:depends("type", "trojan")
+o:depends("type", "hysteria")
 
 if is_installed("sagernet-core") then
 	o = s:option(ListValue, "packet_encoding", translate("Packet Encoding"))

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -311,7 +311,8 @@ local hysteria = {
 	ca = (server.certificate) and server.certpath or nil,
 	recv_window_conn = tonumber(server.recv_window_conn),
 	recv_window = tonumber(server.recv_window),
-	disable_mtu_discovery = (server.disable_mtu_discovery == "1") and true or false
+	disable_mtu_discovery = (server.disable_mtu_discovery == "1") and true or false,
+	fast_open = (server.fast_open == "1") and true or false
 }
 local config = {}
 function config:new(o)


### PR DESCRIPTION
Fast Open can shave off one RTT for every connection at the cost of the correct semantics of SOCKS5/HTTP/TUN protocols. When enabled, the client will always accept a connection immediately without confirming with the server that its destination is reachable. If the server then fails to connect or rejects the connection, the client will just close it without sending any data.