### PR TITLE
Add libopenssl-legacy to fix chipher failure on openwrt 23 with openssl 3.0

### DIFF
--- a/shadowsocksr-libev/Makefile
+++ b/shadowsocksr-libev/Makefile
@@ -34,7 +34,7 @@ define Package/shadowsocksr-libev/Default
     SUBMENU:=Web Servers/Proxies
     TITLE:=shadowsocksr-libev ssr-$(1)
     URL:=https://github.com/shadowsocksrr/shadowsocksr-libev
-    DEPENDS:=+libev +libsodium +libopenssl +libpthread +libpcre +libudns +zlib
+    DEPENDS:=+libev +libsodium +libopenssl +libpthread +libpcre +libudns +zlib +libopenssl-legacy
   endef
 
   define Package/shadowsocksr-libev-ssr-$(1)/install


### PR DESCRIPTION
https://github.com/openssl/openssl/issues/11847