### PR TITLE
luci-app-ssr-plus: add Xray-core `xudpConcurrency` `xudpProxyUDP443` `tcpcongestion` `tcpMptcp` `tcpNoDelay`

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -920,12 +920,35 @@ o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
 o:depends({type = "v2ray", v2ray_protocol = "socks"})
 o:depends({type = "v2ray", v2ray_protocol = "http"})
 
-o = s:option(Value, "concurrency", translate("Concurrency"))
-o.datatype = "uinteger"
+o = s:option(Value, "concurrency", translate("concurrency"))
+o.datatype = "integer"
 o.rmempty = true
-o.default = "4"
+o.default = "-1"
 o:depends("mux", "1")
-o:depends("type", "naiveproxy")
+
+o = s:option(Value, "xudpConcurrency", translate("xudpConcurrency"))
+o.datatype = "integer"
+o.rmempty = true
+o.default = "16"
+o:depends("mux", "1")
+
+o = s:option(Value, "xudpProxyUDP443", translate("xudpProxyUDP443"))
+o.rmempty = true
+o.default = "reject"
+o:value("reject", translate("reject"))
+o:value("allow", translate("allow"))
+o:value("skip", translate("skip"))
+o:depends("mux", "1")
+
+-- [[ MPTCP ]]--
+o = s:option(Flag, "mptcp", translate("MPTCP"))
+o.rmempty = false
+o:depends({type = "v2ray", v2ray_protocol = "vless"})
+o:depends({type = "v2ray", v2ray_protocol = "vmess"})
+o:depends({type = "v2ray", v2ray_protocol = "trojan"})
+o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
+o:depends({type = "v2ray", v2ray_protocol = "socks"})
+o:depends({type = "v2ray", v2ray_protocol = "http"})
 
 -- [[ Cert ]]--
 o = s:option(Flag, "certificate", translate("Self-signed Certificate"))

--- a/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
@@ -88,8 +88,14 @@ msgstr "TLS 主机名"
 msgid "allowInsecure"
 msgstr "允许不安全连接"
 
-msgid "Concurrency"
-msgstr "最大并发连接数"
+msgid "concurrency"
+msgstr "TCP 最大并发连接数"
+
+msgid "xudpConcurrency"
+msgstr "UDP 最大并发连接数"
+
+msgid "xudpProxyUDP443"
+msgstr "对被代理的 UDP/443 流量处理方式"
 
 msgid "If true, allowss insecure connection at TLS client, e.g., TLS server uses unverifiable certificates."
 msgstr "是否允许不安全连接。当选择时，将不会检查远端主机所提供的 TLS 证书的有效性。"

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -125,7 +125,7 @@ local Xray = {
 		port = tonumber(local_port),
 		protocol = "dokodemo-door",
 		settings = {network = proto, followRedirect = true},
-		sniffing = {enabled = true, destOverride = {"http", "tls"}}
+		sniffing = {enabled = true, destOverride = {"http", "tls", "quic"}}
 	} or nil,
 	-- 开启 socks 代理
 	inboundDetour = (proto:find("tcp") and socks_port ~= "0") and {
@@ -156,7 +156,6 @@ local Xray = {
 				} or nil
 			} or nil,
 			realitySettings = (server.reality == '1') and {
-				show = false,
 				publicKey = server.reality_publickey,
 				shortId = server.reality_shortid,
 				spiderX = server.reality_spiderx,
@@ -175,6 +174,7 @@ local Xray = {
 				}
 			} or nil,
 			kcpSettings = (server.transport == "kcp") and {
+				-- kcp
 				mtu = tonumber(server.mtu),
 				tti = tonumber(server.tti),
 				uplinkCapacity = tonumber(server.uplink_capacity),
@@ -216,12 +216,19 @@ local Xray = {
 				health_check_timeout = tonumber(server.health_check_timeout) or nil,
 				permit_without_stream = (server.permit_without_stream == "1") and true or nil,
 				initial_windows_size = tonumber(server.initial_windows_size) or nil
+			} or nil,
+			sockopt = (server.mptcp == "1") and {
+				tcpcongestion = "bbr",
+				tcpMptcp = true,
+				tcpNoDelay = true
 			} or nil
 		},
-		mux = (server.mux == "1" and server.transport ~= "grpc") and {
+		mux = (server.mux == "1") and {
 			-- mux
 			enabled = true,
-			concurrency = tonumber(server.concurrency)
+			concurrency = tonumber(server.concurrency),
+			xudpConcurrency = tonumber(server.xudpConcurrency),
+			xudpProxyUDP443 = server.xudpProxyUDP443
 		} or nil
 	} or nil
 }


### PR DESCRIPTION
MUX生成的配置如下
```jsonc
            "mux": {
                "enabled": true,
                "concurrency": -1, // -1表示不启用TCP MUX，作为默认值
                "xudpConcurrency": 16, // 表示启用 UDP MUX，默认值16
                "xudpProxyUDP443": "reject" // 阻止 UDP 443 流量，默认值
            }
```

当普通用户选中MUX时，使用这套默认值是最佳设置。

![屏幕截图 2024-01-01 003739](https://github.com/fw876/helloworld/assets/88967758/b1248f3d-0d24-4671-afbd-a4dbe17b827b)

用户勾选 MPTCP 时
配置文件生成如下内容。取消勾选则不生成

```
      "sockopt": {
        "tcpcongestion": "bbr",
        "tcpMptcp": true,
        "tcpNoDelay": true
      },
```
