### PR TITLE
luci-app-ssr-plus: Optimal `hysteria2` allocation

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -218,7 +218,7 @@ o:depends("type", "ss")
 o:depends("type", "v2ray")
 o:depends("type", "trojan")
 o:depends("type", "naiveproxy")
-o:depends({type = "hysteria",port_hopping = false})
+o:depends("type", "hysteria")
 o:depends("type", "tuic")
 o:depends("type", "shadowtls")
 o:depends("type", "socks5")
@@ -341,7 +341,7 @@ o.default = "30"
 
 o = s:option(Value, "port_range", translate("Port Range"))
 o:depends({type = "hysteria", port_hopping = true})
-o.rmempty = false
+o.rmempty = true
 
 o = s:option(Flag, "lazy_mode", translate("Enable Lazy Mode"))
 o:depends("type", "hysteria")

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -285,7 +285,7 @@ local ss = {
 	reuse_port = true
 }
 local hysteria = {
-	server = server.server_port and (server.server .. ":" .. server.server_port) or (server.server .. ":" .. server.port_range),
+	server = (server.port_range and (server.server .. ":" .. server.port_range)) or (server.server_port and (server.server .. ":" .. server.server_port)),
 	bandwidth = {
 	up = tonumber(server.uplink_capacity) and tonumber(server.uplink_capacity) .. " mbps" or nil,
 	down = tonumber(server.downlink_capacity) and tonumber(server.downlink_capacity) .. " mbps" or nil 
@@ -327,6 +327,7 @@ local hysteria = {
 	auth = server.hy2_auth,
 	tls = (server.tls_host) and {
 		sni = server.tls_host,
+		alpn = server.tls_alpn or nil,
 		insecure = (server.insecure == "1") and true or false,
 		pinSHA256 = (server.insecure == "1") and server.pinsha256 or nil
 	} or {


### PR DESCRIPTION
优化修改情况：
1、取消端口跳跃时点击“保存和应用”无效，在右上角必须再次保存和应用，此修改修复此问题；
2、启用端口跳跃时，自动隐藏了节点原来配置的单端口，导致服务器列表为乱码字符且无法`ping`延迟和无法看到节点测试显示是否`ok`，此修改实现仍然显示节点端口。
3、此修改仍然显示节点端口并启用端口跳跃时，配置能改为端口跳跃设置的端口范围，如取消端口跳跃，配置改为节点端口；
4、增加可配置使用`apln`;
截图为设置端口跳跃后显示原单端口和`ping`值：
![image](https://github.com/fw876/helloworld/assets/45259624/c74393d8-3c44-4d7b-bd8c-13ddb714bccd)
截图为设置端口跳跃的界面：
![image](https://github.com/fw876/helloworld/assets/45259624/841ef492-840e-4dd8-92d4-e93473efa205)


