### PR TITLE
luci-app-ssr-plus: Only in log display `Hhysteria2` version number

### DIFF
--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -433,7 +433,7 @@ start_udp() {
 	hysteria)
 		gen_config_file $UDP_RELAY_SERVER $type 2 $tmp_udp_port
 		ln_start_bin $(first_type hysteria) hysteria client --config $udp_config_file
-		echolog "UDP TPROXY Relay:$($(first_type "hysteria") version | awk '{print "Hhysteria: "$2}' | head -9 | tail +9) Started!"
+		echolog "UDP TPROXY Relay:$($(first_type "hysteria") version | awk '{print "Hhysteria2: " $2}' | head -9 | tail +9) Started!"
 		;;
 	tuic)
 		# FIXME: ipt2socks cannot handle udp reply from tuic
@@ -564,7 +564,7 @@ start_shunt() {
 		fi
 		ln_start_bin $(first_type hysteria) hysteria client --config $shunt_config_file
 		shunt_dns_command
-		echolog "shunt:$($(first_type hysteria) version | awk '{print "Hhysteria: "$2}' | head -9 | tail +9) Started!"
+		echolog "shunt:$($(first_type hysteria) version | awk '{print "Hhysteria2: " $2}' | head -9 | tail +9) Started!"
 		;;
 	tuic)
 		local chain_shunt_port="30${tmp_shunt_port}"
@@ -663,7 +663,7 @@ start_local() {
 		if [ "$_local" == "2" ]; then
 			gen_config_file $LOCAL_SERVER $type 4 0 $local_port
 			ln_start_bin $(first_type hysteria) hysteria client --config $local_config_file
-			echolog "Global_Socks5:$($(first_type hysteria) version | awk '{print "Hhysteria: "$2}' | head -9 | tail +9) Started!"
+			echolog "Global_Socks5:$($(first_type hysteria) version | awk '{print "Hhysteria2: " $2}' | head -9 | tail +9) Started!"
 		fi
 		;;
 	tuic)
@@ -758,7 +758,7 @@ Start_Run() {
 	hysteria)
 		gen_config_file $GLOBAL_SERVER $type 1 $tcp_port $socks_port
 		ln_start_bin $(first_type hysteria) hysteria client --config $tcp_config_file
-		echolog "Main node:$($(first_type hysteria) version | awk '{print "Hhysteria: "$2}' | head -9 | tail +9) Started!"
+		echolog "Main node:$($(first_type hysteria) version | awk '{print "Hhysteria2: " $2}' | head -9 | tail +9) Started!"
 		;;
 	tuic)
 		local PARAM

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -433,7 +433,7 @@ start_udp() {
 	hysteria)
 		gen_config_file $UDP_RELAY_SERVER $type 2 $tmp_udp_port
 		ln_start_bin $(first_type hysteria) hysteria client --config $udp_config_file
-		echolog "UDP TPROXY Relay:$($(first_type "hysteria") version | awk '{print "Hhysteria: " $2}' | head -9 | tail +9) Started!"
+		echolog "UDP TPROXY Relay:$($(first_type "hysteria") version | awk '{print "Hhysteria: "$2}' | head -9 | tail +9) Started!"
 		;;
 	tuic)
 		# FIXME: ipt2socks cannot handle udp reply from tuic
@@ -564,7 +564,7 @@ start_shunt() {
 		fi
 		ln_start_bin $(first_type hysteria) hysteria client --config $shunt_config_file
 		shunt_dns_command
-		echolog "shunt:$($(first_type hysteria) version | awk '{print "Hhysteria: " $2}' | head -9 | tail +9) Started!"
+		echolog "shunt:$($(first_type hysteria) version | awk '{print "Hhysteria: "$2}' | head -9 | tail +9) Started!"
 		;;
 	tuic)
 		local chain_shunt_port="30${tmp_shunt_port}"
@@ -663,7 +663,7 @@ start_local() {
 		if [ "$_local" == "2" ]; then
 			gen_config_file $LOCAL_SERVER $type 4 0 $local_port
 			ln_start_bin $(first_type hysteria) hysteria client --config $local_config_file
-			echolog "Global_Socks5:$($(first_type hysteria) version | awk '{print "Hhysteria: " $2}' | head -9 | tail +9) Started!"
+			echolog "Global_Socks5:$($(first_type hysteria) version | awk '{print "Hhysteria: "$2}' | head -9 | tail +9) Started!"
 		fi
 		;;
 	tuic)
@@ -758,7 +758,7 @@ Start_Run() {
 	hysteria)
 		gen_config_file $GLOBAL_SERVER $type 1 $tcp_port $socks_port
 		ln_start_bin $(first_type hysteria) hysteria client --config $tcp_config_file
-		echolog "Main node:$($(first_type hysteria) version | awk '{print "Hhysteria: " $2}' | head -9 | tail +9) Started!"
+		echolog "Main node:$($(first_type hysteria) version | awk '{print "Hhysteria: "$2}' | head -9 | tail +9) Started!"
 		;;
 	tuic)
 		local PARAM

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -433,7 +433,7 @@ start_udp() {
 	hysteria)
 		gen_config_file $UDP_RELAY_SERVER $type 2 $tmp_udp_port
 		ln_start_bin $(first_type hysteria) hysteria client --config $udp_config_file
-		echolog "UDP TPROXY Relay:$($(first_type "hysteria") version | awk '{print $1,$2}') Started!"
+		echolog "UDP TPROXY Relay:$($(first_type "hysteria") version | awk '{print "Hhysteria: " $2}' | head -9 | tail +9) Started!"
 		;;
 	tuic)
 		# FIXME: ipt2socks cannot handle udp reply from tuic
@@ -564,7 +564,7 @@ start_shunt() {
 		fi
 		ln_start_bin $(first_type hysteria) hysteria client --config $shunt_config_file
 		shunt_dns_command
-		echolog "shunt:$($(first_type hysteria) version | awk '{print $1,$2}') Started!"
+		echolog "shunt:$($(first_type hysteria) version | awk '{print "Hhysteria: " $2}' | head -9 | tail +9) Started!"
 		;;
 	tuic)
 		local chain_shunt_port="30${tmp_shunt_port}"
@@ -663,7 +663,7 @@ start_local() {
 		if [ "$_local" == "2" ]; then
 			gen_config_file $LOCAL_SERVER $type 4 0 $local_port
 			ln_start_bin $(first_type hysteria) hysteria client --config $local_config_file
-			echolog "Global_Socks5:$($(first_type hysteria) version | awk '{print $1,$2}') Started!"
+			echolog "Global_Socks5:$($(first_type hysteria) version | awk '{print "Hhysteria: " $2}' | head -9 | tail +9) Started!"
 		fi
 		;;
 	tuic)
@@ -758,7 +758,7 @@ Start_Run() {
 	hysteria)
 		gen_config_file $GLOBAL_SERVER $type 1 $tcp_port $socks_port
 		ln_start_bin $(first_type hysteria) hysteria client --config $tcp_config_file
-		echolog "Main node:$($(first_type hysteria) version | awk '{print $1,$2}') Started!"
+		echolog "Main node:$($(first_type hysteria) version | awk '{print "Hhysteria: " $2}' | head -9 | tail +9) Started!"
 		;;
 	tuic)
 		local PARAM


### PR DESCRIPTION
目前`Hhysteria2`运行后会在日志中显示一大串涉及`Hhysteria2`的相关内容，看起来很凌乱不直观。

修改前的效果图：
![image](https://github.com/fw876/helloworld/assets/45259624/adfb5716-18d1-4483-8228-1d6ff2ab0a13)

修改后的效果图：
![image](https://github.com/fw876/helloworld/assets/45259624/b2aa699c-c74d-4c35-aed6-5c42c99e4bbb)
