### PR TITLE
luci-app-ssr-plus: add Xray-core `domainsExcluded`

### DIFF
--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -125,7 +125,37 @@ local Xray = {
 		port = tonumber(local_port),
 		protocol = "dokodemo-door",
 		settings = {network = proto, followRedirect = true},
-		sniffing = {enabled = true, destOverride = {"http", "tls", "quic"}}
+		sniffing = {
+			enabled = true,
+			destOverride = {"http", "tls", "quic"},
+			domainsExcluded = {
+				"courier.push.apple.com",
+				"rbsxbxp-mim.vivox.com",
+				"rbsxbxp.www.vivox.com",
+				"rbsxbxp-ws.vivox.com",
+				"rbspsxp.www.vivox.com",
+				"rbspsxp-mim.vivox.com",
+				"rbspsxp-ws.vivox.com",
+				"rbswxp.www.vivox.com",
+				"rbswxp-mim.vivox.com",
+				"disp-rbspsp-5-1.vivox.com",
+				"disp-rbsxbp-5-1.vivox.com",
+				"proxy.rbsxbp.vivox.com",
+				"proxy.rbspsp.vivox.com",
+				"proxy.rbswp.vivox.com",
+				"rbswp.vivox.com",
+				"rbsxbp.vivox.com",
+				"rbspsp.vivox.com",
+				"rbspsp.www.vivox.com",
+				"rbswp.www.vivox.com",
+				"rbsxbp.www.vivox.com",
+				"rbsxbxp.vivox.com",
+				"rbspsxp.vivox.com",
+				"rbswxp.vivox.com",
+				"Mijia Cloud",
+				"dlg.io.mi.com"
+			}
+		}
 	} or nil,
 	-- 开启 socks 代理
 	inboundDetour = (proto:find("tcp") and socks_port ~= "0") and {


### PR DESCRIPTION
在入站 sniffing 参数下新增 `domainsExcluded`。解决米家智能设备，iOS 推送通知，某些游戏（彩虹六号）语音问题。

`domainsExcluded` 普通用户基本不会使用，不需像passwall一样做成选框让用户可填。

建议使用下面网址（感谢passwall的收集贡献）

```json
    "sniffing": {
      "enabled": true,
      "destOverride": [
        "http",
        "tls",
        "quic"
      ],
      "domainsExcluded": [
        "courier.push.apple.com",
        "rbsxbxp-mim.vivox.com",
        "rbsxbxp.www.vivox.com",
        "rbsxbxp-ws.vivox.com",
        "rbspsxp.www.vivox.com",
        "rbspsxp-mim.vivox.com",
        "rbspsxp-ws.vivox.com",
        "rbswxp.www.vivox.com",
        "rbswxp-mim.vivox.com",
        "disp-rbspsp-5-1.vivox.com",
        "disp-rbsxbp-5-1.vivox.com",
        "proxy.rbsxbp.vivox.com",
        "proxy.rbspsp.vivox.com",
        "proxy.rbswp.vivox.com",
        "rbswp.vivox.com",
        "rbsxbp.vivox.com",
        "rbspsp.vivox.com",
        "rbspsp.www.vivox.com",
        "rbswp.www.vivox.com",
        "rbsxbp.www.vivox.com",
        "rbsxbxp.vivox.com",
        "rbspsxp.vivox.com",
        "rbswxp.vivox.com",
        "Mijia Cloud",
        "dlg.io.mi.com"
      ],
```

相关链接：


https://github.com/XTLS/Xray-core/discussions/364#discussion-3268358

https://github.com/xiaorouji/openwrt-passwall2/pull/8#issue-1167437739

https://github.com/xiaorouji/openwrt-passwall/pull/2885