### PR TITLE
luci-app-ssr-plus: add Xray `DNS` `Log` Setting options Simplifying `Mux` Options

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -117,7 +117,8 @@ local securitys = {
 local tls_flows = {
 	-- tls
 	"xtls-rprx-vision",
-	"xtls-rprx-vision-udp443"
+	"xtls-rprx-vision-udp443",
+	"none"
 }
 
 m = Map("shadowsocksr", translate("Edit ShadowSocksR Server"))
@@ -868,7 +869,7 @@ if is_finded("xray") then
 	o:depends({type = "v2ray", v2ray_protocol = "vless", reality = true})
 
 	-- [[ XTLS ]]--
-	o = s:option(Value, "tls_flow", translate("Flow"))
+	o = s:option(ListValue, "tls_flow", translate("Flow"))
 	for _, v in ipairs(tls_flows) do
 		o:value(v, translate(v))
 	end
@@ -878,7 +879,7 @@ if is_finded("xray") then
 
 	-- [[ uTLS ]]--
 	o = s:option(Value, "fingerprint", translate("Finger Print"))
-	o:value("", translate("disable"))
+	o.default = "chrome"
 	o:value("chrome", translate("chrome"))
 	o:value("firefox", translate("firefox"))
 	o:value("safari", translate("safari"))
@@ -889,6 +890,7 @@ if is_finded("xray") then
 	o:value("qq", translate("qq"))
 	o:value("random", translate("random"))
 	o:value("randomized", translate("randomized"))
+	o:value("", translate("disable"))
 	o:depends({type = "v2ray", tls = true})
 	o:depends({type = "v2ray", reality = true})
 end
@@ -917,6 +919,7 @@ o = s:option(Value, "pinsha256", translate("Certificate fingerprint"))
 o:depends({type = "hysteria", insecure = true })
 o.rmempty = true
 
+
 -- [[ Mux ]]--
 o = s:option(Flag, "mux", translate("Mux"))
 o.rmempty = false
@@ -928,25 +931,28 @@ o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
 o:depends({type = "v2ray", v2ray_protocol = "socks"})
 o:depends({type = "v2ray", v2ray_protocol = "http"})
 
-o = s:option(Value, "concurrency", translate("concurrency"))
-o.datatype = "integer"
+o = s:option(ListValue, "concurrency", translate("concurrency"))
 o.rmempty = true
 o.default = "-1"
+o:value("-1", translate("disable"))
+o:value("8", translate("8"))
 o:depends("mux", true)
 
-o = s:option(Value, "xudpConcurrency", translate("xudpConcurrency"))
-o.datatype = "integer"
+o = s:option(ListValue, "xudpConcurrency", translate("xudpConcurrency"))
 o.rmempty = true
 o.default = "16"
+o:value("16", translate("16"))
+o:value("-1", translate("disable"))
 o:depends("mux", true)
 
-o = s:option(Value, "xudpProxyUDP443", translate("xudpProxyUDP443"))
+o = s:option(ListValue, "xudpProxyUDP443", translate("xudpProxyUDP443"))
 o.rmempty = true
 o.default = "reject"
 o:value("reject", translate("reject"))
 o:value("allow", translate("allow"))
 o:value("skip", translate("skip"))
 o:depends("mux", true)
+
 
 -- [[ MPTCP ]]--
 o = s:option(Flag, "mptcp", translate("MPTCP"))
@@ -959,14 +965,14 @@ o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
 o:depends({type = "v2ray", v2ray_protocol = "socks"})
 o:depends({type = "v2ray", v2ray_protocol = "http"})
 
--- [[ custom_tcpcongestion ]]--
-o = s:option(Value, "custom_tcpcongestion", translate("custom_tcpcongestion"))
+-- [[ custom_tcpcongestion 连接服务器节点的 TCP 拥塞控制算法 ]]--
+o = s:option(ListValue, "custom_tcpcongestion", translate("custom_tcpcongestion"))
 o.rmempty = true
 o.default = ""
 o:value("", translate("comment_tcpcongestion_disable"))
-o:value("bbr", translate("bbr"))
-o:value("cubic", translate("cubic"))
-o:value("reno", translate("reno"))
+o:value("bbr", translate("BBR"))
+o:value("cubic", translate("CUBIC"))
+o:value("reno", translate("Reno"))
 o:depends({type = "v2ray", v2ray_protocol = "vless"})
 o:depends({type = "v2ray", v2ray_protocol = "vmess"})
 o:depends({type = "v2ray", v2ray_protocol = "trojan"})
@@ -974,7 +980,8 @@ o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
 o:depends({type = "v2ray", v2ray_protocol = "socks"})
 o:depends({type = "v2ray", v2ray_protocol = "http"})
 
--- [[ custom_sniffing ]]--
+
+-- [[ custom_sniffing 流量嗅探 ]]--
 o = s:option(Flag, "custom_sniffing", translate("custom_sniffing"))
 o.rmempty = false
 o.default = true
@@ -985,17 +992,124 @@ o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
 o:depends({type = "v2ray", v2ray_protocol = "socks"})
 o:depends({type = "v2ray", v2ray_protocol = "http"})
 
--- [[ custom_domainsExcluded ]]--
+-- [[ custom_domainsExcluded 流量嗅探域名排除列表 ]]--
 o = s:option(Flag, "custom_domainsExcluded", translate("custom_domainsExcluded"))
 o.rmempty = false
 o.default = true
 o:depends("custom_sniffing", true)
 
--- [[ custom_routeOnly ]]--
+-- [[ custom_routeOnly 嗅探得到的域名仅用于 Xray 路由 ]]--
 o = s:option(Flag, "custom_routeOnly", translate("custom_routeOnly"))
 o.rmempty = false
 o.default = false
 o:depends("custom_sniffing", true)
+
+
+-- [[ custom_dns_enable Xray DNS 功能 ]]--
+o = s:option(Flag, "custom_dns_enable", translate("custom_dns_enable"))
+o.rmempty = false
+o.default = false
+o:depends({type = "v2ray", v2ray_protocol = "vless"})
+o:depends({type = "v2ray", v2ray_protocol = "vmess"})
+o:depends({type = "v2ray", v2ray_protocol = "trojan"})
+o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
+o:depends({type = "v2ray", v2ray_protocol = "socks"})
+o:depends({type = "v2ray", v2ray_protocol = "http"})
+o.description = translate("comment_dns_inbound_enable")
+
+-- [[ custom_dns_local 本地 DNS ]]--
+o = s:option(ListValue, "custom_dns_local", translate("custom_dns_local"))
+o.rmempty = true
+o.default = "https+local://223.5.5.5/dns-query"
+o:value("https+local://223.5.5.5/dns-query", translate("https+local://223.5.5.5/dns-query"))
+o:value("https+local://119.29.29.29/dns-query", translate("https+local://119.29.29.29/dns-query"))
+o:depends("custom_dns_enable", true)
+
+-- [[ custom_dns_remote 远端 DNS ]]--
+o = s:option(ListValue, "custom_dns_remote", translate("custom_dns_remote"))
+o.rmempty = true
+o.default = "https://1.1.1.1/dns-query"
+o:value("https://1.1.1.1/dns-query", translate("https://1.1.1.1/dns-query"))
+o:value("https://8.8.8.8/dns-query", translate("https://8.8.8.8/dns-query"))
+o:depends("custom_dns_enable", true)
+
+-- [[ custom_dns_remote_domains 远端 DNS 域名列表 ]]--
+o = s:option(ListValue, "custom_dns_remote_domains", translate("custom_dns_remote_domains"))
+o.rmempty = true
+o.default = "geosite:geolocation-!cn"
+o:value("geosite:geolocation-!cn", translate("geosite:geolocation-!cn"))
+o:depends("custom_dns_enable", true)
+
+-- [[ custom_nonIPQuery 非 A 和 AAAA 记录处理方式 ]]--
+o = s:option(ListValue, "custom_nonIPQuery", translate("custom_nonIPQuery"))
+o.rmempty = true
+o.default = "skip"
+o:value("skip", translate("skip"))
+o:value("drop", translate("drop"))
+o:depends("custom_dns_enable", true)
+
+-- [[ custom_nonIPQuery_outbound_tag 非 A 和 AAAA 记录查询方式 ]]--
+o = s:option(ListValue, "custom_nonIPQuery_outbound_tag", translate("custom_nonIPQuery_outbound_tag"))
+o.rmempty = true
+o.default = "direct"
+o:value("direct", translate("direct"))
+o:value("proxy", translate("proxy"))
+o:depends({custom_nonIPQuery = "skip"})
+
+-- [[ custom_dokodemo_door_dns_address 查询非 A 和 AAAA 记录 DNS ]]--
+o = s:option(ListValue, "custom_dokodemo_door_dns_address", translate("custom_dokodemo_door_dns_address"))
+o.rmempty = true
+o.default = "223.5.5.5"
+o:value("223.5.5.5", translate("223.5.5.5"))
+o:value("119.29.29.29", translate("119.29.29.29"))
+o:value("1.1.1.1", translate("1.1.1.1"))
+o:value("8.8.8.8", translate("8.8.8.8"))
+o:depends({custom_nonIPQuery = "skip"})
+
+
+-- [[ custom_log Xray 日志功能 ]]--
+o = s:option(Flag, "custom_log", translate("custom_log"))
+o.rmempty = false
+o.default = false
+o:depends({type = "v2ray", v2ray_protocol = "vless"})
+o:depends({type = "v2ray", v2ray_protocol = "vmess"})
+o:depends({type = "v2ray", v2ray_protocol = "trojan"})
+o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
+o:depends({type = "v2ray", v2ray_protocol = "socks"})
+o:depends({type = "v2ray", v2ray_protocol = "http"})
+
+-- [[ custom_loglevel 日志级别 ]]--
+o = s:option(ListValue, "custom_loglevel", translate("custom_loglevel"))
+o.rmempty = true
+o.default = "warning"
+o:value("error", translate("error"))
+o:value("warning", translate("warning"))
+o:value("info", translate("info"))
+o:value("debug", translate("debug"))
+o:depends("custom_log", true)
+
+-- [[ custom_dnsLog DNS 查询记录 ]]--
+o = s:option(Flag, "custom_dnsLog", translate("custom_dnsLog"))
+o.rmempty = true
+o.default = true
+o:depends("custom_log", true)
+
+-- [[ custom_access 访问记录 ]]--
+o = s:option(ListValue, "custom_access", translate("custom_access"))
+o.rmempty = true
+o.default = "/tmp/access.log"
+o:value("/tmp/access.log", translate("/tmp/access.log"))
+o:value("none", translate("none"))
+o:depends("custom_log", true)
+
+-- [[ custom_error 错误记录 ]]--
+o = s:option(ListValue, "custom_error", translate("custom_error"))
+o.rmempty = true
+o.default = "/tmp/error.log"
+o:value("/tmp/error.log", translate("/tmp/error.log"))
+o:value("none", translate("none"))
+o:depends("custom_log", true)
+
 
 -- [[ Cert ]]--
 o = s:option(Flag, "certificate", translate("Self-signed Certificate"))

--- a/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
@@ -88,6 +88,7 @@ msgstr "TLS 主机名"
 msgid "allowInsecure"
 msgstr "允许不安全连接"
 
+
 msgid "concurrency"
 msgstr "TCP 最大并发连接数"
 
@@ -97,11 +98,13 @@ msgstr "UDP 最大并发连接数"
 msgid "xudpProxyUDP443"
 msgstr "对被代理的 UDP/443 流量处理方式"
 
+
 msgid "custom_tcpcongestion"
 msgstr "连接服务器节点的 TCP 拥塞控制算法"
 
 msgid "comment_tcpcongestion_disable"
 msgstr "使用系统默认值"
+
 
 msgid "custom_sniffing"
 msgstr "流量嗅探"
@@ -110,7 +113,49 @@ msgid "custom_domainsExcluded"
 msgstr "流量嗅探域名排除列表"
 
 msgid "custom_routeOnly"
-msgstr "嗅探得到的域名仅用于 Xray 内部路由"
+msgstr "嗅探得到的域名仅用于 Xray 路由"
+
+
+msgid "custom_dns_enable"
+msgstr "Xray DNS 功能"
+
+msgid "comment_dns_inbound_enable"
+msgstr "监听 5335 端口，需要上传 geosite.dat 到 /usr/share/xray，更新固件后要重新上传"
+
+msgid "custom_dns_local"
+msgstr "本地 DNS"
+
+msgid "custom_dns_remote"
+msgstr "远端 DNS"
+
+msgid "custom_dns_remote_domains"
+msgstr "远端 DNS 域名列表"
+
+msgid "custom_dokodemo_door_dns_address"
+msgstr "查询非 A 和 AAAA 记录 DNS"
+
+msgid "custom_nonIPQuery"
+msgstr "非 A 和 AAAA 记录处理方式"
+
+msgid "custom_nonIPQuery_outbound_tag"
+msgstr "非 A 和 AAAA 记录查询方式"
+
+
+msgid "custom_log"
+msgstr "Xray 日志功能"
+
+msgid "custom_loglevel"
+msgstr "日志级别"
+
+msgid "custom_dnsLog"
+msgstr "DNS 查询记录"
+
+msgid "custom_access"
+msgstr "访问记录"
+
+msgid "custom_error"
+msgstr "错误记录"
+
 
 msgid "If true, allowss insecure connection at TLS client, e.g., TLS server uses unverifiable certificates."
 msgstr "是否允许不安全连接。当选择时，将不会检查远端主机所提供的 TLS 证书的有效性。"

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -116,21 +116,57 @@ end
 local settings = outbound:new()
 settings:handleIndex(server.v2ray_protocol)
 local Xray = {
-	log = {
-		-- error = "/var/ssrplus.log",
-		loglevel = "warning"
+	-- 日志
+	log = (server.custom_log == "1") and {
+		loglevel = server.custom_loglevel, -- 日志级别
+		dnsLog = (server.custom_dnsLog == "1") and true or false, -- DNS 查询记录
+		access = server.custom_access, -- 访问记录
+		error = server.custom_error -- 错误记录
+	} or nil,
+	-- DNS
+	dns = {
+		hosts = {
+			["dns.alidns.com"] = "223.5.5.5",
+			["doh.pub"] = "119.29.29.29"
+		},
+		servers = (server.custom_dns_enable == "1") and { -- Xray 内置 DNS
+			server.custom_dns_local, -- 本地 DNS
+			{
+				address = server.custom_dns_remote, -- 远端 DNS
+				domains = {
+					server.custom_dns_remote_domains -- 远端 DNS 域名列表
+				},
+				skipFallback = true,
+				queryStrategy = "UseIP"
+			}
+		} or nil,
+		queryStrategy = "UseIP"
+	},
+	-- 路由
+	routing = {
+		domainStrategy = "AsIs",
+		rules = {
+			{
+				type = "field",
+				inboundTag = {
+					"dns-in"
+				},
+				outboundTag = "dns-out"
+			}
+		}
 	},
 	-- 传入连接
-	inbound = (local_port ~= "0") and {
+	inbounds = {
+	(local_port ~= "0") and {
 		-- listening
 		port = tonumber(local_port),
 		protocol = "dokodemo-door",
 		settings = {network = proto, followRedirect = true},
 		sniffing = {
-			enabled =  (server.custom_sniffing == "1") and true or false,
-			routeOnly = (server.custom_routeOnly == "1") and true or false,
+			enabled = (server.custom_sniffing == "1") and true or false, -- 流量嗅探
+			routeOnly = (server.custom_routeOnly == "1") and true or false, -- 嗅探得到的域名仅用于 Xray 内部路由
 			destOverride = {"http", "tls", "quic"},
-			domainsExcluded = (server.custom_domainsExcluded == "1") and {
+			domainsExcluded = (server.custom_domainsExcluded == "1") and { -- 流量嗅探域名排除列表
 				"courier.push.apple.com",
 				"rbsxbxp-mim.vivox.com",
 				"rbsxbxp.www.vivox.com",
@@ -159,6 +195,17 @@ local Xray = {
 			} or nil,
 		}
 	} or nil,
+	(server.custom_dns_enable == "1") and { -- Xray 内置 DNS
+		port = 5335,
+		protocol = "dokodemo-door",
+		settings = {
+			address = server.custom_dokodemo_door_dns_address, -- 查询非 A 和 AAAA 记录DNS
+			port = 53,
+			network = "udp"
+		},
+		tag = "dns-in"
+	} or nil,
+	},
 	-- 开启 socks 代理
 	inboundDetour = (proto:find("tcp") and socks_port ~= "0") and {
 		{
@@ -169,7 +216,9 @@ local Xray = {
 		}
 	} or nil,
 	-- 传出连接
-	outbound = {
+	outbounds = {
+	{
+		tag = "proxy",
 		protocol = server.v2ray_protocol,
 		settings = outbound_settings,
 		-- 底层传输配置
@@ -185,7 +234,7 @@ local Xray = {
 				certificates = server.certificate and {
 					usage = "verify",
 					certificateFile = server.certpath
-				} or nil
+				} or nil,
 			} or nil,
 			realitySettings = (server.reality == '1') and {
 				publicKey = server.reality_publickey,
@@ -250,19 +299,45 @@ local Xray = {
 				initial_windows_size = tonumber(server.initial_windows_size) or nil
 			} or nil,
 			sockopt = {
-				tcpMptcp = (server.mptcp == "1") and true or false,
-				tcpNoDelay = (server.mptcp == "1") and true or false,
-				tcpcongestion = server.custom_tcpcongestion
+				tcpMptcp = (server.mptcp == "1") and true or false, -- MPTCP
+				tcpNoDelay = (server.mptcp == "1") and true or false, -- MPTCP
+				tcpcongestion = server.custom_tcpcongestion -- 连接服务器节点的 TCP 拥塞控制算法
 			}
 		},
-		mux = (server.mux == "1") and {
-			-- mux
-			enabled = true,
-			concurrency = tonumber(server.concurrency),
-			xudpConcurrency = tonumber(server.xudpConcurrency),
-			xudpProxyUDP443 = server.xudpProxyUDP443
-		} or nil
-	} or nil
+		mux = {
+			enabled = (server.mux == "1") and true or false, -- Mux
+			concurrency = tonumber(server.concurrency), -- TCP 最大并发连接数
+			xudpConcurrency = tonumber(server.xudpConcurrency), -- UDP 最大并发连接数
+			xudpProxyUDP443 = server.xudpProxyUDP443 -- 对被代理的 UDP/443 流量处理方式
+		}
+	},
+	{
+		protocol = "freedom",
+		settings = {
+			domainStrategy = "ForceIPv6v4"
+		},
+		streamSettings = {
+			sockopt = {
+				tcpFastOpen = true
+			}
+		},
+		tag = "direct"
+	},
+	{
+		protocol = "blackhole",
+		tag = "block"
+	},
+	(server.custom_dns_enable == "1") and { -- Xray 内置 DNS
+		protocol = "dns",
+		settings = {
+			nonIPQuery = server.custom_nonIPQuery -- 非 A 和 AAAA 记录处理方式
+		},
+		proxySettings = (server.custom_nonIPQuery == "skip") and {
+			tag = server.custom_nonIPQuery_outbound_tag -- 非 A 和 AAAA 记录查询方式
+		} or nil,
+		tag = "dns-out"
+	} or nil,
+	}
 }
 local cipher = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:AES128-SHA:AES256-SHA:DES-CBC3-SHA"
 local cipher13 = "TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384"


### PR DESCRIPTION
1. 将 VLESS 中的 `流控（Flow）`默认值调整为 `xtls-rprx-vision` ，新增一个值 `none`，对话框调整为不允许用户输入自定义内容
2. 将指纹伪造默认值调整为 `chrome` ，`禁用`移至最后
3. Mux中的 `TCP 最大并发连接数` 默认值`-1`，翻译为`禁用（disable）`，不允许用户输入自定义内容，另一个选项是 `8`。以减少普通用户不会调遇错机率。
4. Mux中的 `UDP 最大并发连接数` 默认值`16`，第2个选项是值是`-1`，`禁用（disable）`，禁用后按Xray文档讲的SS就是用协议本身规定的原生UDP，trojan协议就是UoT行为。不允许用户输入自定义内容。以减少普通用户不会调遇错机率。
5. 新增加 `Xray DNS 功能` 和 `Xray 日志功能`，由于新手水平，只做了固定选项让用户选的模式，对话框都不允许用户输入自定义内容，以减少输错后Xray配置出错启动失败机率。使用时把 `DNS 解析方式` 改为 使用本机5335的DNS服务即可。但是要用户手动上传geosite.dat文件。
`远端 DNS 域名列表`指 `geosite:geolocation-!cn` 分类中的域名，使用远端 DNS查询，远端DNS是`走代理`发送请求到服务端。剩下没命中的域名，使用国内DNS直连出站查询（DoH）。

![1](https://github.com/fw876/helloworld/assets/88967758/8e89ea1e-42ed-4622-90bc-7ba29878741a)
![2](https://github.com/fw876/helloworld/assets/88967758/b4529295-10f6-4e4e-956f-b7c86332f58c)
![3](https://github.com/fw876/helloworld/assets/88967758/361857f2-2b46-44f0-b8e0-1c5e32e5fdf3)
