### PR TITLE
luci-app-ssr-plus: Xray cancel changes #1370 #1374

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -931,6 +931,7 @@ o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
 o:depends({type = "v2ray", v2ray_protocol = "socks"})
 o:depends({type = "v2ray", v2ray_protocol = "http"})
 
+-- [[ TCP 最大并发连接数 ]]--
 o = s:option(ListValue, "concurrency", translate("concurrency"))
 o.rmempty = true
 o.default = "-1"
@@ -938,13 +939,15 @@ o:value("-1", translate("disable"))
 o:value("8", translate("8"))
 o:depends("mux", true)
 
+-- [[ UDP 最大并发连接数 ]]--
 o = s:option(ListValue, "xudpConcurrency", translate("xudpConcurrency"))
 o.rmempty = true
 o.default = "16"
-o:value("16", translate("16"))
 o:value("-1", translate("disable"))
+o:value("16", translate("16"))
 o:depends("mux", true)
 
+-- [[ 对被代理的 UDP/443 流量处理方式 ]]--
 o = s:option(ListValue, "xudpProxyUDP443", translate("xudpProxyUDP443"))
 o.rmempty = true
 o.default = "reject"
@@ -979,136 +982,6 @@ o:depends({type = "v2ray", v2ray_protocol = "trojan"})
 o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
 o:depends({type = "v2ray", v2ray_protocol = "socks"})
 o:depends({type = "v2ray", v2ray_protocol = "http"})
-
-
--- [[ custom_sniffing 流量嗅探 ]]--
-o = s:option(Flag, "custom_sniffing", translate("custom_sniffing"))
-o.rmempty = false
-o.default = true
-o:depends({type = "v2ray", v2ray_protocol = "vless"})
-o:depends({type = "v2ray", v2ray_protocol = "vmess"})
-o:depends({type = "v2ray", v2ray_protocol = "trojan"})
-o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
-o:depends({type = "v2ray", v2ray_protocol = "socks"})
-o:depends({type = "v2ray", v2ray_protocol = "http"})
-
--- [[ custom_domainsExcluded 流量嗅探域名排除列表 ]]--
-o = s:option(Flag, "custom_domainsExcluded", translate("custom_domainsExcluded"))
-o.rmempty = false
-o.default = true
-o:depends("custom_sniffing", true)
-
--- [[ custom_routeOnly 嗅探得到的域名仅用于 Xray 路由 ]]--
-o = s:option(Flag, "custom_routeOnly", translate("custom_routeOnly"))
-o.rmempty = false
-o.default = false
-o:depends("custom_sniffing", true)
-
-
--- [[ custom_dns_enable Xray DNS 功能 ]]--
-o = s:option(Flag, "custom_dns_enable", translate("custom_dns_enable"))
-o.rmempty = false
-o.default = false
-o:depends({type = "v2ray", v2ray_protocol = "vless"})
-o:depends({type = "v2ray", v2ray_protocol = "vmess"})
-o:depends({type = "v2ray", v2ray_protocol = "trojan"})
-o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
-o:depends({type = "v2ray", v2ray_protocol = "socks"})
-o:depends({type = "v2ray", v2ray_protocol = "http"})
-o.description = translate("comment_dns_inbound_enable")
-
--- [[ custom_dns_local 本地 DNS ]]--
-o = s:option(ListValue, "custom_dns_local", translate("custom_dns_local"))
-o.rmempty = true
-o.default = "https+local://223.5.5.5/dns-query"
-o:value("https+local://223.5.5.5/dns-query", translate("https+local://223.5.5.5/dns-query"))
-o:value("https+local://119.29.29.29/dns-query", translate("https+local://119.29.29.29/dns-query"))
-o:depends("custom_dns_enable", true)
-
--- [[ custom_dns_remote 远端 DNS ]]--
-o = s:option(ListValue, "custom_dns_remote", translate("custom_dns_remote"))
-o.rmempty = true
-o.default = "https://1.1.1.1/dns-query"
-o:value("https://1.1.1.1/dns-query", translate("https://1.1.1.1/dns-query"))
-o:value("https://8.8.8.8/dns-query", translate("https://8.8.8.8/dns-query"))
-o:depends("custom_dns_enable", true)
-
--- [[ custom_dns_remote_domains 远端 DNS 域名列表 ]]--
-o = s:option(ListValue, "custom_dns_remote_domains", translate("custom_dns_remote_domains"))
-o.rmempty = true
-o.default = "geosite:geolocation-!cn"
-o:value("geosite:geolocation-!cn", translate("geosite:geolocation-!cn"))
-o:depends("custom_dns_enable", true)
-
--- [[ custom_nonIPQuery 非 A 和 AAAA 记录处理方式 ]]--
-o = s:option(ListValue, "custom_nonIPQuery", translate("custom_nonIPQuery"))
-o.rmempty = true
-o.default = "skip"
-o:value("skip", translate("skip"))
-o:value("drop", translate("drop"))
-o:depends("custom_dns_enable", true)
-
--- [[ custom_nonIPQuery_outbound_tag 非 A 和 AAAA 记录查询方式 ]]--
-o = s:option(ListValue, "custom_nonIPQuery_outbound_tag", translate("custom_nonIPQuery_outbound_tag"))
-o.rmempty = true
-o.default = "direct"
-o:value("direct", translate("direct"))
-o:value("proxy", translate("proxy"))
-o:depends({custom_nonIPQuery = "skip"})
-
--- [[ custom_dokodemo_door_dns_address 查询非 A 和 AAAA 记录 DNS ]]--
-o = s:option(ListValue, "custom_dokodemo_door_dns_address", translate("custom_dokodemo_door_dns_address"))
-o.rmempty = true
-o.default = "223.5.5.5"
-o:value("223.5.5.5", translate("223.5.5.5"))
-o:value("119.29.29.29", translate("119.29.29.29"))
-o:value("1.1.1.1", translate("1.1.1.1"))
-o:value("8.8.8.8", translate("8.8.8.8"))
-o:depends({custom_nonIPQuery = "skip"})
-
-
--- [[ custom_log Xray 日志功能 ]]--
-o = s:option(Flag, "custom_log", translate("custom_log"))
-o.rmempty = false
-o.default = false
-o:depends({type = "v2ray", v2ray_protocol = "vless"})
-o:depends({type = "v2ray", v2ray_protocol = "vmess"})
-o:depends({type = "v2ray", v2ray_protocol = "trojan"})
-o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
-o:depends({type = "v2ray", v2ray_protocol = "socks"})
-o:depends({type = "v2ray", v2ray_protocol = "http"})
-
--- [[ custom_loglevel 日志级别 ]]--
-o = s:option(ListValue, "custom_loglevel", translate("custom_loglevel"))
-o.rmempty = true
-o.default = "warning"
-o:value("error", translate("error"))
-o:value("warning", translate("warning"))
-o:value("info", translate("info"))
-o:value("debug", translate("debug"))
-o:depends("custom_log", true)
-
--- [[ custom_dnsLog DNS 查询记录 ]]--
-o = s:option(Flag, "custom_dnsLog", translate("custom_dnsLog"))
-o.rmempty = true
-o.default = true
-o:depends("custom_log", true)
-
--- [[ custom_access 访问记录 ]]--
-o = s:option(ListValue, "custom_access", translate("custom_access"))
-o.rmempty = true
-o.default = "/tmp/access.log"
-o:value("/tmp/access.log", translate("/tmp/access.log"))
-o:value("none", translate("none"))
-o:depends("custom_log", true)
-
--- [[ custom_error 错误记录 ]]--
-o = s:option(ListValue, "custom_error", translate("custom_error"))
-o.rmempty = true
-o.default = "/tmp/error.log"
-o:value("/tmp/error.log", translate("/tmp/error.log"))
-o:value("none", translate("none"))
-o:depends("custom_log", true)
 
 
 -- [[ Cert ]]--

--- a/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
@@ -103,58 +103,7 @@ msgid "custom_tcpcongestion"
 msgstr "连接服务器节点的 TCP 拥塞控制算法"
 
 msgid "comment_tcpcongestion_disable"
-msgstr "使用系统默认值"
-
-
-msgid "custom_sniffing"
-msgstr "流量嗅探"
-
-msgid "custom_domainsExcluded"
-msgstr "流量嗅探域名排除列表"
-
-msgid "custom_routeOnly"
-msgstr "嗅探得到的域名仅用于 Xray 路由"
-
-
-msgid "custom_dns_enable"
-msgstr "Xray DNS 功能"
-
-msgid "comment_dns_inbound_enable"
-msgstr "监听 5335 端口，需要上传 geosite.dat 到 /usr/share/xray，更新固件后要重新上传"
-
-msgid "custom_dns_local"
-msgstr "本地 DNS"
-
-msgid "custom_dns_remote"
-msgstr "远端 DNS"
-
-msgid "custom_dns_remote_domains"
-msgstr "远端 DNS 域名列表"
-
-msgid "custom_dokodemo_door_dns_address"
-msgstr "查询非 A 和 AAAA 记录 DNS"
-
-msgid "custom_nonIPQuery"
-msgstr "非 A 和 AAAA 记录处理方式"
-
-msgid "custom_nonIPQuery_outbound_tag"
-msgstr "非 A 和 AAAA 记录查询方式"
-
-
-msgid "custom_log"
-msgstr "Xray 日志功能"
-
-msgid "custom_loglevel"
-msgstr "日志级别"
-
-msgid "custom_dnsLog"
-msgstr "DNS 查询记录"
-
-msgid "custom_access"
-msgstr "访问记录"
-
-msgid "custom_error"
-msgstr "错误记录"
+msgstr "系统默认值"
 
 
 msgid "If true, allowss insecure connection at TLS client, e.g., TLS server uses unverifiable certificates."

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -116,57 +116,20 @@ end
 local settings = outbound:new()
 settings:handleIndex(server.v2ray_protocol)
 local Xray = {
-	-- 日志
-	log = (server.custom_log == "1") and {
-		loglevel = server.custom_loglevel, -- 日志级别
-		dnsLog = (server.custom_dnsLog == "1") and true or false, -- DNS 查询记录
-		access = server.custom_access, -- 访问记录
-		error = server.custom_error -- 错误记录
-	} or nil,
-	-- DNS
-	dns = {
-		hosts = {
-			["dns.alidns.com"] = "223.5.5.5",
-			["doh.pub"] = "119.29.29.29"
-		},
-		servers = (server.custom_dns_enable == "1") and { -- Xray 内置 DNS
-			server.custom_dns_local, -- 本地 DNS
-			{
-				address = server.custom_dns_remote, -- 远端 DNS
-				domains = {
-					server.custom_dns_remote_domains -- 远端 DNS 域名列表
-				},
-				skipFallback = true,
-				queryStrategy = "UseIP"
-			}
-		} or nil,
-		queryStrategy = "UseIP"
-	},
-	-- 路由
-	routing = {
-		domainStrategy = "AsIs",
-		rules = {
-			{
-				type = "field",
-				inboundTag = {
-					"dns-in"
-				},
-				outboundTag = "dns-out"
-			}
-		}
+	log = {
+		-- error = "/var/ssrplus.log",
+		loglevel = "warning"
 	},
 	-- 传入连接
-	inbounds = {
-	(local_port ~= "0") and {
+	inbound = (local_port ~= "0") and {
 		-- listening
 		port = tonumber(local_port),
 		protocol = "dokodemo-door",
 		settings = {network = proto, followRedirect = true},
 		sniffing = {
-			enabled = (server.custom_sniffing == "1") and true or false, -- 流量嗅探
-			routeOnly = (server.custom_routeOnly == "1") and true or false, -- 嗅探得到的域名仅用于 Xray 内部路由
+			enabled = true,
 			destOverride = {"http", "tls", "quic"},
-			domainsExcluded = (server.custom_domainsExcluded == "1") and { -- 流量嗅探域名排除列表
+			domainsExcluded = {
 				"courier.push.apple.com",
 				"rbsxbxp-mim.vivox.com",
 				"rbsxbxp.www.vivox.com",
@@ -192,20 +155,9 @@ local Xray = {
 				"rbswxp.vivox.com",
 				"Mijia Cloud",
 				"dlg.io.mi.com"
-			} or nil,
+			}
 		}
 	} or nil,
-	(server.custom_dns_enable == "1") and { -- Xray 内置 DNS
-		port = 5335,
-		protocol = "dokodemo-door",
-		settings = {
-			address = server.custom_dokodemo_door_dns_address, -- 查询非 A 和 AAAA 记录DNS
-			port = 53,
-			network = "udp"
-		},
-		tag = "dns-in"
-	} or nil,
-	},
 	-- 开启 socks 代理
 	inboundDetour = (proto:find("tcp") and socks_port ~= "0") and {
 		{
@@ -216,9 +168,7 @@ local Xray = {
 		}
 	} or nil,
 	-- 传出连接
-	outbounds = {
-	{
-		tag = "proxy",
+	outbound = {
 		protocol = server.v2ray_protocol,
 		settings = outbound_settings,
 		-- 底层传输配置
@@ -305,38 +255,12 @@ local Xray = {
 			}
 		},
 		mux = {
+			-- mux
 			enabled = (server.mux == "1") and true or false, -- Mux
 			concurrency = tonumber(server.concurrency), -- TCP 最大并发连接数
 			xudpConcurrency = tonumber(server.xudpConcurrency), -- UDP 最大并发连接数
 			xudpProxyUDP443 = server.xudpProxyUDP443 -- 对被代理的 UDP/443 流量处理方式
 		}
-	},
-	{
-		protocol = "freedom",
-		settings = {
-			domainStrategy = "ForceIPv6v4"
-		},
-		streamSettings = {
-			sockopt = {
-				tcpFastOpen = true
-			}
-		},
-		tag = "direct"
-	},
-	{
-		protocol = "blackhole",
-		tag = "block"
-	},
-	(server.custom_dns_enable == "1") and { -- Xray 内置 DNS
-		protocol = "dns",
-		settings = {
-			nonIPQuery = server.custom_nonIPQuery -- 非 A 和 AAAA 记录处理方式
-		},
-		proxySettings = (server.custom_nonIPQuery == "skip") and {
-			tag = server.custom_nonIPQuery_outbound_tag -- 非 A 和 AAAA 记录查询方式
-		} or nil,
-		tag = "dns-out"
-	} or nil,
 	}
 }
 local cipher = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:AES128-SHA:AES256-SHA:DES-CBC3-SHA"


### PR DESCRIPTION
我测试发现当将 `DNS 解析方式` 设置为 `使用本机为 5335 端口` 时，由  https://github.com/fw876/helloworld/pull/1370 https://github.com/fw876/helloworld/pull/1374 新增的使用`Xray自己DNS`功能，并没有生效。我的能力有限，不能解决这一个问题。

我将Xray配置更改部分退回为 https://github.com/fw876/helloworld/pull/1362 的状态。

此时界面功能界面

![屏幕截图 2024-01-15 022536](https://github.com/fw876/helloworld/assets/88967758/1b1ca0c9-0cfd-4776-94eb-fe86579f27a2)

MUX默认`不勾选`，如果勾选了，TCP MUX默认值禁用，UDP MUX默认是16

MPTCP默认`不勾选`

对服务器节点的TCP拥塞控制默认是`系统默认值`

取消`流量嗅探`的按钮，SSRP一直没做这按钮，也没有ISS反应有需求，保持简单即好原则，不更改了。