### PR TITLE
luci-app-ssr-plus: `udp` Only used to customize the underlying protoc…

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -323,16 +323,16 @@ o = s:option(Value, "hy2_auth", translate("Users Authentication"))
 o:depends("type", "hysteria")
 o.rmempty = false
 
-o = s:option(ListValue, "transport_protocol", translate("Protocol"))
-o:depends("type", "hysteria")
-o:value("udp", translate("udp"))
-o.default = "udp"
-o.rmempty = true
-
 o = s:option(Flag, "port_hopping", translate("Enable Port Hopping"))
 o:depends("type", "hysteria")
 o.rmempty = true
 o.default = "0"
+
+o = s:option(ListValue, "transport_protocol", translate("Protocol"))
+o:depends({type = "hysteria", port_hopping = true})
+o:value("udp", translate("udp"))
+o.default = "udp"
+o.rmempty = true
 
 o = s:option(Value, "hopinterval", translate("Port Hopping Interval(Unit:Second)"))
 o:depends({type = "hysteria", port_hopping = true})

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -429,7 +429,7 @@ local hysteria = {
 		maxConnReceiveWindow = (server.maxconnreceivewindow and server.maxconnreceivewindow or nil),
 		maxIdleTimeout = (tonumber(server.maxidletimeout) and tonumber(server.maxidletimeout) .. "s" or nil),
 		keepAlivePeriod = (tonumber(server.keepaliveperiod) and tonumber(server.keepaliveperiod) .. "s" or nil),
-		disable_mtu_discovery = (server.disablepathmtudiscovery == "1") and true or false
+		disablePathMTUDiscovery = (server.disablepathmtudiscovery == "1") and true or false
 	} or nil,
 	auth = server.hy2_auth,
 	tls = (server.tls_host) and {

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -401,12 +401,12 @@ local hysteria = {
 		listen = "0.0.0.0:" .. tonumber(socks_port),
 		disable_udp = false
 	} or nil,
-	transport = {
+	transport = (server.port_hopping == "1") and {
 		type = server.transport_protocol,
 		udp = { 
-			hopInterval = tonumber(server.hopinterval) and tonumber(server.hopinterval) .. "s" or "30s"
+			hopInterval = tonumber(server.hopinterval) and tonumber(server.hopinterval) .. "s" or nil
 		}
-	},
+	} or nil,
 --[[			
 	tcpTProxy = (proto:find("tcp") and local_port ~= "0") and {
 	listen = "0.0.0.0:" .. tonumber(local_port)


### PR DESCRIPTION
…ol used for QUIC connections

**根据官方的配置说明：`udp`仅在配置端口跳跃时启用，因此，未配置端口跳跃时，不需默认启用`udp`协议。见下面的官方部分说明！**
传输 (Transport)
transport 用于自定义 QUIC 连接使用的底层协议。目前唯一可用的类型是 udp，保留类型选项是为了将来可能添加的其他类型。 
````
transport:
  type: udp
  udp:
    hopInterval: 30s
`````
![image](https://github.com/fw876/helloworld/assets/45259624/7792811f-799b-4ae6-bfd8-e4e7f6d86f3a)
