### PR TITLE
luci-app-ssr-plus: add http global server

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
@@ -125,7 +125,7 @@ o.rawhtml = true
 o.template = "shadowsocksr/reset"
 
 -- [[ SOCKS5 Proxy ]]--
-s = m:section(TypedSection, "socks5_proxy", translate("Global SOCKS5 Proxy Server"))
+s = m:section(TypedSection, "local_proxy", translate("Global SOCKS5 HTTP Proxy Server"))
 s.anonymous = true
 
 o = s:option(ListValue, "server", translate("Server"))
@@ -137,9 +137,14 @@ end
 o.default = "nil"
 o.rmempty = false
 
-o = s:option(Value, "local_port", translate("Local Port"))
+o = s:option(Value, "socks5_port", translate("Local SOCKS5 Port"))
 o.datatype = "port"
 o.default = 1080
+o.rmempty = false
+
+o = s:option(Value, "http_port", translate("Local HTTP Port"))
+o.datatype = "port"
+o.default = 1081
 o.rmempty = false
 
 return m

--- a/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
@@ -52,6 +52,12 @@ msgstr "端口"
 msgid "Local Port"
 msgstr "本地端口"
 
+msgid "Local SOCKS5 Port"
+msgstr "SOCKS5 本地端口"
+
+msgid "Local HTTP Port"
+msgstr "HTTP 本地端口"
+
 msgid "Connection Timeout"
 msgstr "连接超时"
 
@@ -873,8 +879,8 @@ msgstr "服务端类型"
 msgid "Local Servers"
 msgstr "本机服务端"
 
-msgid "Global SOCKS5 Proxy Server"
-msgstr "SOCKS5 代理服务端（全局）"
+msgid "Global SOCKS5 HTTP Proxy Server"
+msgstr "SOCKS5/HTTP 代理服务端（全局）"
 
 msgid "warning! Please do not reuse the port!"
 msgstr "警告！请不要重复使用端口！"

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -299,7 +299,7 @@ get_name() {
 	esac
 }
 
-gen_config_file() { #server1 type2 code3 local_port4 socks_port5 chain6 threads5
+gen_config_file() { #server1 type2 code3 local_port4 socks_port5 http_port chain6 threads5
 	case "$3" in
 	1)
 		config_file=$tcp_config_file
@@ -332,7 +332,7 @@ gen_config_file() { #server1 type2 code3 local_port4 socks_port5 chain6 threads5
 		fi
 		;;
 	v2ray)
-		lua /usr/share/shadowsocksr/gen_config.lua $1 $mode $4 $5 >$config_file
+		lua /usr/share/shadowsocksr/gen_config.lua $1 $mode $4 $5 $6 >$config_file
 		;;
 	trojan)
 		case "$3" in
@@ -374,18 +374,18 @@ gen_config_file() { #server1 type2 code3 local_port4 socks_port5 chain6 threads5
 			lua /usr/share/shadowsocksr/gen_config.lua $1 $mode $4 >$config_file
 			;;
 		3)
-			[ -z "$6" ] && lua /usr/share/shadowsocksr/gen_config.lua $1 $mode $4 >$shunt_dns_config_file || lua /usr/share/shadowsocksr/gen_config.lua $1 $mode $4 >$config_file
+			[ -z "$7" ] && lua /usr/share/shadowsocksr/gen_config.lua $1 $mode $4 >$shunt_dns_config_file || lua /usr/share/shadowsocksr/gen_config.lua $1 $mode $4 >$config_file
 			;;
 		esac
 		;;
 	shadowtls)
 		case "$3" in
 		1|2|4)
-			[ -z "$6" ] && lua /usr/share/shadowsocksr/gen_config.lua $1 $type $4 >$chain_config_file || lua /usr/share/shadowsocksr/gen_config.lua $1 $mode $4 $5 $6 >$config_file
+			[ -z "$7" ] && lua /usr/share/shadowsocksr/gen_config.lua $1 $type $4 >$chain_config_file || lua /usr/share/shadowsocksr/gen_config.lua $1 $mode $4 $5 0 $7 >$config_file
 			;;
 		3)
 			lua /usr/share/shadowsocksr/gen_config.lua $1 $type $4 >$chain_config_file
-			lua /usr/share/shadowsocksr/gen_config.lua $1 $mode $4 $5 $6 >$config_file
+			lua /usr/share/shadowsocksr/gen_config.lua $1 $mode $4 $5 0 $7 >$config_file
 			;;
 		esac
 		;;
@@ -448,7 +448,7 @@ start_udp() {
 		;;
 	shadowtls)
 		gen_config_file $UDP_RELAY_SERVER $type 2 ${tmp_udp_local_port}
-		gen_config_file $UDP_RELAY_SERVER $type 2 ${tmp_udp_local_port} 0 chain
+		gen_config_file $UDP_RELAY_SERVER $type 2 ${tmp_udp_local_port} 0 0 chain
 		ln_start_bin $(first_type shadow-tls) shadow-tls config --config $chain_config_file
 		local chain_type=$(uci_get_by_name $UDP_RELAY_SERVER chain_type)
 		case ${chain_type} in
@@ -568,7 +568,7 @@ start_shunt() {
 		;;
 	tuic)
 		local chain_shunt_port="30${tmp_shunt_port}"
-		gen_config_file $SHUNT_SERVER $type 3 $chain_shunt_port 0 chain #make a tuic socks:30303, make a ipt2socks redir:303
+		gen_config_file $SHUNT_SERVER $type 3 $chain_shunt_port 0 0 chain #make a tuic socks:30303, make a ipt2socks redir:303
 		ln_start_bin $(first_type tuic-client) tuic-client --config $shunt_config_file
 		ln_start_bin $(first_type ipt2socks) ipt2socks -R -b 0.0.0.0 -4 -s 127.0.0.1 -p $chain_shunt_port -l $tmp_shunt_port
 
@@ -582,7 +582,7 @@ start_shunt() {
 		;;
 	shadowtls)
 		[ -n "$tmp_local_port" ] && tmp_port=$tmp_local_port || tmp_port=$tmp_shunt_local_port
-		gen_config_file $SHUNT_SERVER $type 3 "10${tmp_shunt_port}" $tmp_port chain/$tmp_shunt_port #make a redir:303 and a socks:304
+		gen_config_file $SHUNT_SERVER $type 3 "10${tmp_shunt_port}" $tmp_port 0 chain/$tmp_shunt_port #make a redir:303 and a socks:304
 		#echo "debug \$tmp_port=$tmp_port, \$tmp_shunt_port=${tmp_shunt_port},  \$tmp_shunt_local_port=$tmp_shunt_local_port"
 		ln_start_bin $(first_type shadow-tls) shadow-tls config --config $chain_config_file
 		shunt_dns_command
@@ -632,7 +632,8 @@ start_shunt() {
 
 start_local() {
 	[ "$LOCAL_SERVER" = "nil" ] && return 1
-	local local_port=$(uci_get_by_type socks5_proxy local_port)
+	local local_port=$(uci_get_by_type local_proxy socks5_port)
+	local http_port=$(uci_get_by_type local_proxy http_port)
 	[ "$LOCAL_SERVER" == "$SHUNT_SERVER" ] && tmp_local_port=$local_port
 	local type=$(uci_get_by_name $LOCAL_SERVER type)
 	case "$type" in
@@ -644,7 +645,7 @@ start_local() {
 		;;
 	v2ray)
 		if [ "$_local" == "2" ]; then
-			gen_config_file $LOCAL_SERVER $type 4 0 $local_port
+			gen_config_file $LOCAL_SERVER $type 4 0 $local_port $http_port
 			ln_start_bin $(first_type xray v2ray) v2ray run -config $local_config_file
 		fi
 		echolog "Global_Socks5:$($(first_type "xray" "v2ray") version | head -1) Started!"
@@ -677,7 +678,7 @@ start_local() {
 		#respective config for global socks and main node
 		if [ "$_local" == "2" ]; then
 			gen_config_file $LOCAL_SERVER $type 4 "10${tmp_tcp_local_port}"
-			gen_config_file $LOCAL_SERVER $type 4 0 $local_port chain/"10${tmp_tcp_local_port}"
+			gen_config_file $LOCAL_SERVER $type 4 0 $local_port 0 chain/"10${tmp_tcp_local_port}"
 			ln_start_bin $(first_type shadow-tls) shadow-tls config --config $chain_local_config_file
 			local chain_type=$(uci_get_by_name $LOCAL_SERVER chain_type)
 			case ${chain_type} in
@@ -723,7 +724,8 @@ Start_Run() {
 		ARG_UDP=""
 	fi
 	if [ "$_local" == "1" ]; then
-		local socks_port=$(uci_get_by_type socks5_proxy local_port)
+		local socks_port=$(uci_get_by_type local_proxy socks5_port)
+		local http_port=$(uci_get_by_type local_proxy http_port)
 		tcp_config_file=$TMP_PATH/local-ssr-retcp.json
 		[ "$mode" == "tcp,udp" ] && tcp_config_file=$TMP_PATH/local-udp-ssr-retcp.json
 	fi
@@ -739,7 +741,7 @@ Start_Run() {
 		echolog "Main node:$(get_name $type) $threads Threads Started!"
 		;;
 	v2ray)
-		gen_config_file $GLOBAL_SERVER $type 1 $tcp_port $socks_port
+		gen_config_file $GLOBAL_SERVER $type 1 $tcp_port $socks_port $http_port
 		ln_start_bin $(first_type xray v2ray) v2ray run -config $tcp_config_file
 		echolog "Main node:$($(first_type xray v2ray) version | head -1) Started!"
 		;;
@@ -776,10 +778,10 @@ Start_Run() {
 	shadowtls)
 		if [ -z "$socks_port" ]; then
 			gen_config_file $GLOBAL_SERVER $type 1 "10${tmp_tcp_local_port}"
-			gen_config_file $GLOBAL_SERVER $type 1 "10${tmp_tcp_local_port}" 0 chain
+			gen_config_file $GLOBAL_SERVER $type 1 "10${tmp_tcp_local_port}" 0 0 chain
 		else
 			gen_config_file $GLOBAL_SERVER $type 1 "10${tmp_tcp_local_port}"
-			gen_config_file $GLOBAL_SERVER $type 1 "10${tmp_tcp_local_port}" $socks_port chain
+			gen_config_file $GLOBAL_SERVER $type 1 "10${tmp_tcp_local_port}" $socks_port 0 chain
 		fi
 		local chain_type=$(uci_get_by_name $GLOBAL_SERVER chain_type)
 		case ${chain_type} in
@@ -824,7 +826,7 @@ load_config() {
 	else
 		GLOBAL_SERVER=$switch_server
 	fi
-	LOCAL_SERVER=$(uci_get_by_type socks5_proxy server nil)
+	LOCAL_SERVER=$(uci_get_by_type local_proxy server nil)
 	if [ "$GLOBAL_SERVER" == "nil" ]; then
 		mode="tcp,udp"
 		_local="2"
@@ -1169,9 +1171,10 @@ reset() {
 		add_list shadowsocksr.@access_control[0].wan_fw_ips=91.108.56.0/22
 		add_list shadowsocksr.@access_control[0].wan_fw_ips=109.239.140.0/24
 		add_list shadowsocksr.@access_control[0].Interface='lan'
-		add shadowsocksr socks5_proxy
-		set shadowsocksr.@socks5_proxy[0].server='nil'
-		set shadowsocksr.@socks5_proxy[0].local_port='1080'
+		add shadowsocksr local_proxy
+		set shadowsocksr.@local_proxy[0].server='nil'
+		set shadowsocksr.@local_proxy[0].socks5_port='1080'
+		set shadowsocksr.@local_proxy[0].http_port='1081'
 		add shadowsocksr server_global
 		set shadowsocksr.@server_global[0].enable_server='0'
 		commit shadowsocksr

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -7,8 +7,9 @@ local server_section = arg[1]
 local proto = arg[2]
 local local_port = arg[3] or "0"
 local socks_port = arg[4] or "0"
+local http_port = arg[5] or "0"
 
-local chain = arg[5] or "0"
+local chain = arg[6] or "0"
 local chain_local_port = string.split(chain, "/")[2] or "0"
 
 local server = ucursor:get_all("shadowsocksr", server_section)
@@ -206,14 +207,20 @@ local Xray = {
 		tag = "dns-in"
 	} or nil,
 	},
-	-- 开启 socks 代理
-	inboundDetour = (proto:find("tcp") and socks_port ~= "0") and {
-		{
+	-- 开启 socks/http 代理
+	inboundDetour = (proto:find("tcp")) and {
+		(socks_port ~= "0") and {
 			-- socks
 			protocol = "socks",
 			port = tonumber(socks_port),
 			settings = {auth = "noauth", udp = true}
-		}
+		} or nil,
+		(http_port ~= "0") and {
+			-- http
+			protocol = "http",
+			port = tonumber(http_port),
+			settings = {auth = "noauth", udp = true}
+		} or nil
 	} or nil,
 	-- 传出连接
 	outbounds = {


### PR DESCRIPTION
在Linux终端中可以使用`http_proxy`和`https_proxy`两个环境变量快速设置网络代理，但是目前ssr-plus中并没有提供http代理功能，只有一个全局的socks5代理，本PR主要是在此功能上进行扩充，增加本地http代理端口设置功能。最终效果如图：
<img width="536" alt="Screenshot 2024-02-16 at 12 07 00" src="https://github.com/fw876/helloworld/assets/12405147/c414b13c-242e-4452-b921-ab96e22109c2">

由于本人只有v2ray的测试环境，因此未对其它协议做支持，如果有需要，可以在`luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua`中使用`http_port`全局变量进行相关修改。