### PR TITLE
luci-app-ssr-plus: fix `WireGuard protocol` failure to connect problem.

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -831,8 +831,19 @@ o:depends("transport", "kcp")
 o.rmempty = true
 
 -- [[ WireGuard 部分 ]]--
+o = s:option(Flag, "kernelmode", translate("Enabled Kernel virtual NIC TUN(optional)"))
+o.description = translate("Virtual NIC TUN of Linux kernel can be used only when system supports and have root permission. If used, IPv6 routing table 1023 is occupied.")
+o:depends({type = "v2ray", v2ray_protocol = "wireguard"})
+o.default = "0"
+o.rmempty = true
+
 o = s:option(DynamicList, "local_addresses", translate("Local addresses"))
 o.datatype = "cidr"
+o:depends({type = "v2ray", v2ray_protocol = "wireguard"})
+o.rmempty = true
+
+o = s:option(DynamicList, "reserved", translate("Reserved bytes(optional)"))
+o.description = translate("Wireguard reserved bytes.")
 o:depends({type = "v2ray", v2ray_protocol = "wireguard"})
 o.rmempty = true
 
@@ -848,6 +859,19 @@ o.rmempty = true
 o = s:option(Value, "preshared_key", translate("Pre-shared key"))
 o:depends({type = "v2ray", v2ray_protocol = "wireguard"})
 o.password = true
+o.rmempty = true
+
+o = s:option(Value, "keepalive", translate("Heartbeat interval(second)"))
+o.description = translate("Default value 0 indicatesno heartbeat.")
+o:depends({type = "v2ray", v2ray_protocol = "wireguard"})
+o.default = "0"
+o.rmempty = true
+
+o = s:option(DynamicList, "allowedips", translate("allowedIPs(optional)"))
+o.description = translate("Wireguard allows only traffic from specific source IP.")
+o.datatype = "cidr"
+o:depends({type = "v2ray", v2ray_protocol = "wireguard"})
+o.default = "0.0.0.0/0"
 o.rmempty = true
 
 -- [[ TLS ]]--

--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -525,7 +525,9 @@ o.default = "3"
 o.rmempty = true
 
 o = s:option(Value, "timeout", translate("Timeout for establishing a connection to server(second)"))
+o.description = translate("Default value 0 indicatesno heartbeat.")
 o:depends("type", "tuic")
+o:depends({type = "v2ray", v2ray_protocol = "wireguard"})
 o.datatype = "uinteger"
 o.default = "8"
 o.rmempty = true
@@ -859,12 +861,6 @@ o.rmempty = true
 o = s:option(Value, "preshared_key", translate("Pre-shared key"))
 o:depends({type = "v2ray", v2ray_protocol = "wireguard"})
 o.password = true
-o.rmempty = true
-
-o = s:option(Value, "keepalive", translate("Heartbeat interval(second)"))
-o.description = translate("Default value 0 indicatesno heartbeat.")
-o:depends({type = "v2ray", v2ray_protocol = "wireguard"})
-o.default = "0"
 o.rmempty = true
 
 o = s:option(DynamicList, "allowedips", translate("allowedIPs(optional)"))

--- a/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
@@ -942,8 +942,20 @@ msgstr "写入缓冲区大小"
 msgid "Congestion"
 msgstr "拥塞控制"
 
+msgid "Enabled Kernel virtual NIC TUN(optional)"
+msgstr "启用内核的虚拟网卡 TUN（可选）"
+
+msgid "Virtual NIC TUN of Linux kernel can be used only when system supports and have root permission. If used, IPv6 routing table 1023 is occupied."
+msgstr "需要系统支持且有 root 权限才能使用 Linux 内核的虚拟网卡 TUN，使用后会占用 IPv6 的 1023 号路由表。"
+
 msgid "Local addresses"
 msgstr "本地地址"
+
+msgid "Reserved bytes(optional)"
+msgstr "保留字节（可选）"
+
+msgid "Wireguard reserved bytes."
+msgstr "Wireguard 保留字节。"
 
 msgid "Private key"
 msgstr "私钥"
@@ -953,6 +965,15 @@ msgstr "节点公钥"
 
 msgid "Pre-shared key"
 msgstr "预共享密钥"
+
+msgid "Default value 0 indicatesno heartbeat."
+msgstr "默认为 0 表示无心跳。"
+
+msgid "allowedIPs(optional)"
+msgstr "allowedIPs（可选）"
+
+msgid "Wireguard allows only traffic from specific source IP."
+msgstr "Wireguard 仅允许特定源 IP 的流量。"
 
 msgid "Network interface to use"
 msgstr "使用的网络接口"

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -73,7 +73,7 @@ function wireguard()
 				publicKey = server.peer_pubkey,
 				preSharedKey = server.preshared_key,
 				endpoint = server.server .. ":" .. server.server_port,
-				keepAlive = tonumber(server.keepalive),
+				keepAlive = tonumber(server.heartbeat),
 				allowedIPs = (server.allowedips) or nil,
 			}
 		},


### PR DESCRIPTION
***  Add WireGuard `kernelMode` `keepAlive` `allowedIPs` ` reserved` argument

***  whether to use the virtual NIC TUN of the Linux kernel！Virtual NIC TUN of Linux kernel can be used only when system supports and have root permission.
Some routes cannot be connected if they are used.

*** Current Wireguard protocol `outbound` Is not supported `streamSettings`.

*** fix `WireGuard protocol` failure to connect problem.

![image](https://github.com/fw876/helloworld/assets/45259624/a30be5e6-b964-4fc2-ab10-a32b6def9bf5)
