### PR TITLE
luci-app-ssr-plus: Fix `TUIC` does not run or cannot connect.

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -568,6 +568,7 @@ o.rmempty = true
 
 -- Tuic settings for the local inbound socks5 server
 o = s:option(Flag, "tuic_dual_stack", translate("Dual-stack Listening Socket"))
+o.description = translate("If this option is not set, the socket behavior is platform dependent.")
 o:depends("type", "tuic")
 o.default = "0"
 o.rmempty = true
@@ -941,7 +942,8 @@ o:depends("reality", true)
 o.rmempty = true
 
 o = s:option(DynamicList, "tls_alpn", translate("TLS ALPN"))
-o:depends({type = "tuic", tls = true})
+o:depends("type", "tuic")
+o.default = "h3"
 o.rmempty = true
 
 -- [[ allowInsecure ]]--

--- a/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
@@ -1051,7 +1051,7 @@ msgid "Dual-stack Listening Socket"
 msgstr "双栈Socket监听"
 
 msgid "If this option is not set, the socket behavior is platform dependent."
-msgstr "如果监听套接字未设置为双栈，则套接字的行为取决于平台。"
+msgstr "如果未设置此选项，则套接字行为依赖于平台。"
 
 msgid "Maximum packet size the socks5 server can receive from external"
 msgstr "socks5服务器可以从外部接收的最大数据包大小（单位：字节）"

--- a/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh-cn/ssr-plus.po
@@ -1050,6 +1050,9 @@ msgstr "接收窗口（无需确认即可接收的最大字节数：默认8Mb）
 msgid "Dual-stack Listening Socket"
 msgstr "双栈Socket监听"
 
+msgid "If this option is not set, the socket behavior is platform dependent."
+msgstr "如果监听套接字未设置为双栈，则套接字的行为取决于平台。"
+
 msgid "Maximum packet size the socks5 server can receive from external"
 msgstr "socks5服务器可以从外部接收的最大数据包大小（单位：字节）"
 

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -476,8 +476,8 @@ local tuic = {
 			receive_window = tonumber(server.receive_window)
 		},
 		["local"] = {
-			server = tonumber(socks_port) and (server.tuic_dual_stack == "1" and "[::1]:" or "127.0.0.1:")  .. (socks_port == "0" and local_port or tonumber(socks_port)),
-			dual_stack = (server.tuic_dual_stack == "1") and true or false,
+			server = tonumber(socks_port) and "[::]:" .. (socks_port == "0" and local_port or tonumber(socks_port)),
+			dual_stack = (server.tuic_dual_stack == "1") and true  or nil,
 			max_packet_size = tonumber(server.tuic_max_package_size)
 		}
 }


### PR DESCRIPTION
1、If the listening socket is not set to dual-stack, the socket behavior depends on the platform. 
2、Settings for the local inbound socks5 server should be set to [::] for proper running after the dual-stack configuration.
See official WIKI:
https://github.com/EAimTY/tuic/tree/dev/tuic-client
**效果图：**
![image](https://github.com/fw876/helloworld/assets/45259624/b9cf1144-e659-4b0f-9833-3329512475e4)
![image](https://github.com/fw876/helloworld/assets/45259624/668a975b-443c-4faf-a29b-ba343db6b155)