### PR TITLE
luci-app-ssr-plus: Fixing misconfigurations

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -412,7 +412,9 @@ o.datatype = "uinteger"
 o.default = "30"
 
 o = s:option(Value, "keepaliveperiod", translate("The keep-alive period.(Unit:second)"))
+o.description = translate("Default value 0 indicatesno heartbeat.")
 o:depends({type = "hysteria", flag_quicparam = "1"})
+o:depends({type = "v2ray", v2ray_protocol = "wireguard"})
 o.rmempty = true
 o.datatype = "uinteger"
 o.default = "10"
@@ -525,9 +527,7 @@ o.default = "3"
 o.rmempty = true
 
 o = s:option(Value, "timeout", translate("Timeout for establishing a connection to server(second)"))
-o.description = translate("Default value 0 indicatesno heartbeat.")
 o:depends("type", "tuic")
-o:depends({type = "v2ray", v2ray_protocol = "wireguard"})
 o.datatype = "uinteger"
 o.default = "8"
 o.rmempty = true

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -73,7 +73,7 @@ function wireguard()
 				publicKey = server.peer_pubkey,
 				preSharedKey = server.preshared_key,
 				endpoint = server.server .. ":" .. server.server_port,
-				keepAlive = tonumber(server.heartbeat),
+				keepAlive = tonumber(server.keepaliveperiod),
 				allowedIPs = (server.allowedips) or nil,
 			}
 		},


### PR DESCRIPTION
The heartbeat interval should be configured, incorrectly configured to `Timeout`.