### PR TITLE
luci-app-ssr-plus: Fix tcp protocol imported to Vmess node. Do not select TLS.

### DIFF
--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
@@ -259,11 +259,12 @@ function import_ssr_url(btn, urlname, sid) {
 			if (ssm.net == "tcp") {
 				if (ssm.type && ssm.type != "http") {
 					ssm.type = "none"
+				} else {
+					document.getElementsByName('cbid.shadowsocksr.' + sid + '.http_host')[0].value = ssm.host;
+					document.getElementsByName('cbid.shadowsocksr.' + sid + '.http_path')[0].value = ssm.path;
 				}
 				document.getElementsByName('cbid.shadowsocksr.' + sid + '.tcp_guise')[0].value = ssm.type;
 				document.getElementsByName('cbid.shadowsocksr.' + sid + '.tcp_guise')[0].dispatchEvent(event);
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.http_host')[0].value = ssm.host;
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.http_path')[0].value = ssm.path;
 			}
 			if (ssm.net == "ws") {
 				document.getElementsByName('cbid.shadowsocksr.' + sid + '.ws_host')[0].value = ssm.host;


### PR DESCRIPTION
**修正前导入情况：**
![image](https://github.com/user-attachments/assets/9f06362c-33a3-4521-918c-c0b17513ebbc)
**修正后导入情况：**
![image](https://github.com/user-attachments/assets/37c63642-44f9-4a14-a173-c05359079fcc)
