### PR TITLE
luci-app-ssr-plus: Add `apple domains data` update settings and replace `apple DNS` support.

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
@@ -113,6 +113,17 @@ o = s:option(Flag, "apple_optimization", translate("Apple domains optimization")
 o.rmempty = false
 o.default = "1"
 
+o = s:option(Value, "apple_url", translate("Apple Domains Update url"))
+o:value("https://fastly.jsdelivr.net/gh/felixonmars/dnsmasq-china-list/apple.china.conf", translate("felixonmars/dnsmasq-china-list"))
+o.default = "https://fastly.jsdelivr.net/gh/felixonmars/dnsmasq-china-list/apple.china.conf"
+o:depends("apple_optimization", "1")
+
+o = s:option(Value, "apple_dns", translate("Apple Domains DNS"), translate("If empty, Not change Apple domains parsing DNS (Default is empty)"))
+o.rmempty = true
+o.default = ""
+o.datatype = "ip4addr"
+o:depends("apple_optimization", "1")
+
 o = s:option(Flag, "adblock", translate("Enable adblock"))
 o.rmempty = false
 

--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/status.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/status.lua
@@ -48,6 +48,10 @@ if nixio.fs.access("/etc/ssrplus/china_ssr.txt") then
 	ip_count = tonumber(luci.sys.exec("cat /etc/ssrplus/china_ssr.txt | wc -l"))
 end
 
+if nixio.fs.access("/etc/ssrplus/applechina.conf") then
+	apple_count = tonumber(luci.sys.exec("cat /etc/ssrplus/applechina.conf | wc -l"))
+end
+
 if nixio.fs.access("/etc/ssrplus/netflixip.list") then
 	nfip_count = tonumber(luci.sys.exec("cat /etc/ssrplus/netflixip.list | wc -l"))
 end
@@ -168,6 +172,13 @@ s = m:field(DummyValue, "ip_data", translate("China IP Data"))
 s.rawhtml = true
 s.template = "shadowsocksr/refresh"
 s.value = ip_count .. " " .. translate("Records")
+
+if uci:get_first("shadowsocksr", 'global', 'apple_optimization', '0') ~= '0' then
+	s = m:field(DummyValue, "apple_data", translate("Apple Domains Data"))
+	s.rawhtml = true
+	s.template = "shadowsocksr/refresh"
+	s.value = apple_count .. " " .. translate("Records")
+end
 
 if uci:get_first("shadowsocksr", 'global', 'netflix_enable', '0') ~= '0' then
 s = m:field(DummyValue, "nfip_data", translate("Netflix IP Data"))

--- a/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
@@ -410,6 +410,9 @@ msgstr "【中国大陆 IP 段】数据库"
 msgid "Netflix IP Data"
 msgstr "【Netflix IP 段】数据库"
 
+msgid "Apple Domains Data"
+msgstr "【Apple 域名】数据库"
+
 msgid "Advertising Data"
 msgstr "【广告屏蔽】数据库"
 
@@ -469,6 +472,15 @@ msgstr "启用广告屏蔽"
 
 msgid "adblock_url"
 msgstr "广告屏蔽更新 URL"
+
+msgid "Apple Domains Update url"
+msgstr "Apple 域名更新 URL"
+
+msgid "Apple Domains DNS"
+msgstr "Apple 域名 DNS"
+
+msgid "If empty, Not change Apple domains parsing DNS (Default is empty)"
+msgstr "如果为空，则不更改 Apple 域名解析 DNS（默认为空）"
 
 msgid "gfwlist Update url"
 msgstr "GFW 列表更新 URL"

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -258,6 +258,14 @@ start_dns() {
 	fi
 	
 	if [ "$(uci_get_by_type global apple_optimization 1)" == "1" ]; then
+		local new_appledns="$(uci_get_by_type global apple_dns)"
+		if [ -n "$new_appledns" ]; then		
+			sed -i 's/[[:space:]]//g' /etc/ssrplus/applechina.conf #去除所有空白字符
+			local old_appledns=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' /etc/ssrplus/applechina.conf | sort -u)
+			if [ -n "$old_appledns" ] && [ "$old_appledns" != "$new_appledns" ]; then
+				sed -i "s,$(printf '%s' "$old_appledns"),$(printf '%s' "$new_appledns"),g" /etc/ssrplus/applechina.conf
+			fi
+		fi
 		echolog "Apple 域名中国大陆 CDN 的 优化规则正在加载。"
 		cp -f /etc/ssrplus/applechina.conf $TMP_DNSMASQ_PATH/
 		echolog "Apple 域名中国大陆 CDN 的 优化规则加载完毕。"


### PR DESCRIPTION
说明：apple 域名解析dns可以修改为任意dns且可以为未来有新的apple域名时可以自由选择更新。

此pr为：https://github.com/fw876/helloworld/pull/1615   的重开，原pr太凌乱。