### PR TITLE
luci-app-ssr-plus: servers.lua: Fix when auto update is canceled opton is empty error.

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/servers.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/servers.lua
@@ -29,7 +29,7 @@ o:value("5", translate("Every Friday"))
 o:value("6", translate("Every Saturday"))
 o:value("0", translate("Every Sunday"))
 o.default = "*"
-o.rmempty = false
+o.rmempty = true
 o:depends("auto_update", "1")
 
 o = s:option(ListValue, "auto_update_day_time", translate("Update time (every day)"))
@@ -37,7 +37,7 @@ for t = 0, 23 do
 	o:value(t, t .. ":00")
 end
 o.default = 2
-o.rmempty = false
+o.rmempty = true
 o:depends("auto_update", "1")
 
 o = s:option(ListValue, "auto_update_min_time", translate("Update Interval (min)"))
@@ -45,7 +45,7 @@ for i = 0, 59 do
     o:value(i, i .. ":00")
 end
 o.default = 30
-o.rmempty = false
+o.rmempty = true
 o:depends("auto_update", "1")
 
 o = s:option(DynamicList, "subscribe_url", translate("Subscribe URL"))


### PR DESCRIPTION
**报错提示：**

![image](https://github.com/user-attachments/assets/73bca8e2-2599-4d62-949b-79fa4ce80351)
