### PR TITLE
luci-app-ssr-plus: WS: Forbid "host" in "headers", read "serverName" instead

### DIFF
--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -256,10 +256,7 @@ end
 				} or nil,
 				wsSettings = (server.transport == "ws") and (server.ws_path or server.ws_host or server.tls_host) and {
 					-- ws
-					headers = (server.ws_host or server.tls_host) and {
-						-- headers
-						Host = server.ws_host or server.tls_host
-					} or nil,
+					Host = server.ws_host or server.tls_host or nil,
 					path = server.ws_path,
 					maxEarlyData = tonumber(server.ws_ed) or nil,
 					earlyDataHeaderName = server.ws_ed_header or nil


### PR DESCRIPTION

See: https://github.com/XTLS/Xray-core/commit/a2b773135a860f63e990874c551b099dfc888471

兼容旧版服务器节点。