### PR TITLE
luci-app-ssr-plus: Fix flow control and TCP/RAW transport protocol configurations issues.

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -618,8 +618,7 @@ o:depends({type = "v2ray", v2ray_protocol = "socks"})
 
 -- 传输协议
 o = s:option(ListValue, "transport", translate("Transport"))
-o:value("tcp", "TCP")
-o:value("raw", "RAW")
+o:value("raw", "RAW (TCP)")
 o:value("kcp", "mKCP")
 o:value("ws", "WebSocket")
 o:value("httpupgrade", "HTTPUpgrade")
@@ -635,17 +634,9 @@ o:depends({type = "v2ray", v2ray_protocol = "shadowsocks"})
 o:depends({type = "v2ray", v2ray_protocol = "socks"})
 o:depends({type = "v2ray", v2ray_protocol = "http"})
 
--- [[ TCP部分 ]]--
+-- [[ RAW部分 ]]--
 -- TCP伪装
 o = s:option(ListValue, "tcp_guise", translate("Camouflage Type"))
-o:depends("transport", "tcp")
-o:value("none", translate("None"))
-o:value("http", "HTTP")
-o.rmempty = true
-
--- [[ RAW部分 ]]--
--- RAW伪装
-o = s:option(ListValue, "raw_guise", translate("Camouflage Type"))
 o:depends("transport", "raw")
 o:value("none", translate("None"))
 o:value("http", "HTTP")
@@ -654,13 +645,11 @@ o.rmempty = true
 -- HTTP域名
 o = s:option(Value, "http_host", translate("HTTP Host"))
 o:depends("tcp_guise", "http")
-o:depends("raw_guise", "http")
 o.rmempty = true
 
 -- HTTP路径
 o = s:option(Value, "http_path", translate("HTTP Path"))
 o:depends("tcp_guise", "http")
-o:depends("raw_guise", "http")
 o.rmempty = true
 
 -- [[ WS部分 ]]--
@@ -943,9 +932,7 @@ if is_finded("xray") then
 		end
 	end
 	o.rmempty = true
-	o:depends({type = "v2ray", v2ray_protocol = "vless", transport = "tcp", tls = true})
 	o:depends({type = "v2ray", v2ray_protocol = "vless", transport = "raw", tls = true})
-	o:depends({type = "v2ray", v2ray_protocol = "vless", transport = "tcp", reality = true})
 	o:depends({type = "v2ray", v2ray_protocol = "vless", transport = "raw", reality = true})
 
 	-- [[ uTLS ]]--

--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -935,7 +935,12 @@ if is_finded("xray") then
 	-- [[ XTLS ]]--
 	o = s:option(ListValue, "tls_flow", translate("Flow"))
 	for _, v in ipairs(tls_flows) do
-		o:value(v, translate(v))
+		if v == "none" then
+		   o.default = "none"
+		   o:value("none", translate("none"))
+		else
+		    o:value(v, translate(v))
+		end
 	end
 	o.rmempty = true
 	o:depends({type = "v2ray", v2ray_protocol = "vless", transport = "tcp", tls = true})

--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
@@ -254,11 +254,12 @@ function import_ssr_url(btn, urlname, sid) {
 			document.getElementsByName('cbid.shadowsocksr.' + sid + '.server_port')[0].value = ssm.port;
 			document.getElementsByName('cbid.shadowsocksr.' + sid + '.alter_id')[0].value = ssm.aid;
 			document.getElementsByName('cbid.shadowsocksr.' + sid + '.vmess_id')[0].value = ssm.id;
-			document.getElementsByName('cbid.shadowsocksr.' + sid + '.transport')[0].value = ssm.net;
+			document.getElementsByName('cbid.shadowsocksr.' + sid + '.transport')[0].value = 
+				(ssm.net === "raw" || ssm.net === "tcp") ? "raw" : ssm.net;
 			document.getElementsByName('cbid.shadowsocksr.' + sid + '.transport')[0].dispatchEvent(event);
-			if (ssm.net == "tcp") {
+			if (ssm.net === "raw" || ssm.net === "tcp") {
 				if (ssm.type && ssm.type != "http") {
-					ssm.type = "none"
+					ssm.type = "none";
 				} else {
 					document.getElementsByName('cbid.shadowsocksr.' + sid + '.http_host')[0].value = ssm.host;
 					document.getElementsByName('cbid.shadowsocksr.' + sid + '.http_path')[0].value = ssm.path;
@@ -294,8 +295,10 @@ function import_ssr_url(btn, urlname, sid) {
 				document.getElementsByName('cbid.shadowsocksr.' + sid + '.tls')[0].dispatchEvent(event);
 				document.getElementsByName('cbid.shadowsocksr.' + sid + '.tls_host')[0].value = ssm.sni || ssm.host;
 			}
+			if (ssm.mux !== undefined) {
 			document.getElementsByName('cbid.shadowsocksr.' + sid + '.mux')[0].checked = true;
 			document.getElementsByName('cbid.shadowsocksr.' + sid + '.mux')[0].dispatchEvent(event);
+			}
 			s.innerHTML = "<font style=\'color:green\'><%:Import configuration information successfully.%></font>";
 			return false;
 		case "vless":

--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
@@ -310,7 +310,11 @@ function import_ssr_url(btn, urlname, sid) {
 			function setElementValue(name, value) {
 				const element = document.getElementsByName(name)[0];
 				if (element) {
-					element.value = value;
+					if (element.type === "checkbox" || element.type === "radio") {
+						element.checked = value === true;
+					} else {
+						element.value = value;
+					}
 				}
 			}
 			function dispatchEventIfExists(name, event) {
@@ -335,11 +339,8 @@ function import_ssr_url(btn, urlname, sid) {
 			dispatchEventIfExists('cbid.shadowsocksr.' + sid + '.transport', event);
 			setElementValue('cbid.shadowsocksr.' + sid + '.vless_encryption', params.get("encryption") || "none");
 			if ([ "tls", "xtls", "reality" ].includes(params.get("security"))) {
-				const securityElement = document.getElementsByName('cbid.shadowsocksr.' + sid + '.' + params.get("security"))[0];
-				if (securityElement) {
-					securityElement.checked = true;
-					securityElement.dispatchEvent(event);
-				}
+				setElementValue('cbid.shadowsocksr.' + sid + '.' + params.get("security"), true);
+				dispatchEventIfExists('cbid.shadowsocksr.' + sid + '.' + params.get("security"), event);
 
 				if (params.get("security") === "reality") {
 					setElementValue('cbid.shadowsocksr.' + sid + '.reality_publickey', params.get("pbk") ? decodeURIComponent(params.get("pbk")) : "");

--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
@@ -306,85 +306,104 @@ function import_ssr_url(btn, urlname, sid) {
 				alert(e)
 				return false;
 			}
-
-			document.getElementsByName('cbid.shadowsocksr.' + sid + '.alias')[0].value = url.hash ? decodeURIComponent(url.hash.slice(1)) : "";
-			document.getElementsByName('cbid.shadowsocksr.' + sid + '.type')[0].value = "v2ray";
-			document.getElementsByName('cbid.shadowsocksr.' + sid + '.type')[0].dispatchEvent(event);
-			document.getElementsByName('cbid.shadowsocksr.' + sid + '.v2ray_protocol')[0].value = "vless";
-			document.getElementsByName('cbid.shadowsocksr.' + sid + '.v2ray_protocol')[0].dispatchEvent(event);
-			document.getElementsByName('cbid.shadowsocksr.' + sid + '.server')[0].value = url.hostname;
-			document.getElementsByName('cbid.shadowsocksr.' + sid + '.server_port')[0].value = url.port || "80";
-			document.getElementsByName('cbid.shadowsocksr.' + sid + '.vmess_id')[0].value = url.username;
-			document.getElementsByName('cbid.shadowsocksr.' + sid + '.transport')[0].value = 
-				params.get("type") == "http" ? "h2" : 
-				(params.get("type") == "raw" ? "raw" : 
-				(params.get("type") || "tcp"));
-			document.getElementsByName('cbid.shadowsocksr.' + sid + '.transport')[0].dispatchEvent(event);
-			document.getElementsByName('cbid.shadowsocksr.' + sid + '.vless_encryption')[0].value = params.get("encryption") || "none";
+			// Check if the elements exist before trying to modify them
+			function setElementValue(name, value) {
+				const element = document.getElementsByName(name)[0];
+				if (element) {
+					element.value = value;
+				}
+			}
+			function dispatchEventIfExists(name, event) {
+				const element = document.getElementsByName(name)[0];
+				if (element) {
+					element.dispatchEvent(event);
+				}
+			}
+			setElementValue('cbid.shadowsocksr.' + sid + '.alias', url.hash ? decodeURIComponent(url.hash.slice(1)) : "");
+			setElementValue('cbid.shadowsocksr.' + sid + '.type', "v2ray");
+			dispatchEventIfExists('cbid.shadowsocksr.' + sid + '.type', event);
+			setElementValue('cbid.shadowsocksr.' + sid + '.v2ray_protocol', "vless");
+			dispatchEventIfExists('cbid.shadowsocksr.' + sid + '.v2ray_protocol', event);
+			setElementValue('cbid.shadowsocksr.' + sid + '.server', url.hostname);
+			setElementValue('cbid.shadowsocksr.' + sid + '.server_port', url.port || "80");
+			setElementValue('cbid.shadowsocksr.' + sid + '.vmess_id', url.username);
+			setElementValue('cbid.shadowsocksr.' + sid + '.transport', 
+				params.get("type") === "http" ? "h2" : 
+				(params.get("type") === "raw" ? "raw" : 
+				(params.get("type") || "tcp"))
+			);
+			dispatchEventIfExists('cbid.shadowsocksr.' + sid + '.transport', event);
+			setElementValue('cbid.shadowsocksr.' + sid + '.vless_encryption', params.get("encryption") || "none");
 			if ([ "tls", "xtls", "reality" ].includes(params.get("security"))) {
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.' + params.get("security"))[0].checked = true;
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.' + params.get("security"))[0].dispatchEvent(event);
+				const securityElement = document.getElementsByName('cbid.shadowsocksr.' + sid + '.' + params.get("security"))[0];
+				if (securityElement) {
+					securityElement.checked = true;
+					securityElement.dispatchEvent(event);
+				}
 
 				if (params.get("security") === "reality") {
-					document.getElementsByName('cbid.shadowsocksr.' + sid + '.reality_publickey')[0].value = params.get("pbk") ? decodeURIComponent(params.get("pbk")) : "";
-					document.getElementsByName('cbid.shadowsocksr.' + sid + '.reality_shortid')[0].value = params.get("sid") || "";
-					document.getElementsByName('cbid.shadowsocksr.' + sid + '.reality_spiderx')[0].value = params.get("spx") ? decodeURIComponent(params.get("spx")) : "";
+					setElementValue('cbid.shadowsocksr.' + sid + '.reality_publickey', params.get("pbk") ? decodeURIComponent(params.get("pbk")) : "");
+					setElementValue('cbid.shadowsocksr.' + sid + '.reality_shortid', params.get("sid") || "");
+					setElementValue('cbid.shadowsocksr.' + sid + '.reality_spiderx', params.get("spx") ? decodeURIComponent(params.get("spx")) : "");
 				}
-				if (params.get("security") === "xtls") {
-					document.getElementsByName('cbid.shadowsocksr.' + sid + '.tls_flow')[0].value = params.get("flow") || "";
-					document.getElementsByName('cbid.shadowsocksr.' + sid + '.tls_flow')[0].dispatchEvent(event);
-				}
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.fingerprint')[0].value = params.get("fp") || "";
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.tls_host')[0].value = params.get("sni") || "";
+				setElementValue('cbid.shadowsocksr.' + sid + '.tls_flow', params.get("flow") || "none");
+				dispatchEventIfExists('cbid.shadowsocksr.' + sid + '.tls_flow', event);
+
+				setElementValue('cbid.shadowsocksr.' + sid + '.fingerprint', params.get("fp") || "");
+				setElementValue('cbid.shadowsocksr.' + sid + '.tls_host', params.get("sni") || "");
 			}
 			switch (params.get("type")) {
 			case "ws":
-				if (params.get("security") !== "tls")
-					document.getElementsByName('cbid.shadowsocksr.' + sid + '.ws_host')[0].value = params.get("host") ? decodeURIComponent(params.get("host")) : "";
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.ws_path')[0].value = params.get("path") ? decodeURIComponent(params.get("path")) : "/";
+				if (params.get("security") !== "tls") {
+					setElementValue('cbid.shadowsocksr.' + sid + '.ws_host', params.get("host") ? decodeURIComponent(params.get("host")) : "");
+				}
+				setElementValue('cbid.shadowsocksr.' + sid + '.ws_path', params.get("path") ? decodeURIComponent(params.get("path")) : "/");
 				break;
 			case "httpupgrade":
-				if (params.get("security") !== "tls")
-					document.getElementsByName('cbid.shadowsocksr.' + sid + '.httpupgrade_host')[0].value = params.get("host") ? decodeURIComponent(params.get("host")) : "";
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.httpupgrade_path')[0].value = params.get("path") ? decodeURIComponent(params.get("path")) : "/";
+				if (params.get("security") !== "tls") {
+					setElementValue('cbid.shadowsocksr.' + sid + '.httpupgrade_host', params.get("host") ? decodeURIComponent(params.get("host")) : "");
+				}
+				setElementValue('cbid.shadowsocksr.' + sid + '.httpupgrade_path', params.get("path") ? decodeURIComponent(params.get("path")) : "/");
 				break;
 			case "splithttp":
-				if (params.get("security") !== "tls")
-					document.getElementsByName('cbid.shadowsocksr.' + sid + '.splithttp_host')[0].value = params.get("host") ? decodeURIComponent(params.get("host")) : "";
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.splithttp_path')[0].value = params.get("path") ? decodeURIComponent(params.get("path")) : "/";
+				if (params.get("security") !== "tls") {
+					setElementValue('cbid.shadowsocksr.' + sid + '.splithttp_host', params.get("host") ? decodeURIComponent(params.get("host")) : "");
+				}
+				setElementValue('cbid.shadowsocksr.' + sid + '.splithttp_path', params.get("path") ? decodeURIComponent(params.get("path")) : "/");
 				break;
 			case "kcp":
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.kcp_guise')[0].value = params.get("headerType") || "none";
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.seed')[0].value = params.get("seed") || "";
+				setElementValue('cbid.shadowsocksr.' + sid + '.kcp_guise', params.get("headerType") || "none");
+				setElementValue('cbid.shadowsocksr.' + sid + '.seed', params.get("seed") || "");
 				break;
 			case "http":
 			/* this is non-standard, bullshit */
 			case "h2":
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.h2_host')[0].value = params.get("host") ? decodeURIComponent(params.get("host")) : "";
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.h2_path')[0].value = params.get("path") ? decodeURIComponent(params.get("path")) : "";
+				setElementValue('cbid.shadowsocksr.' + sid + '.h2_host', params.get("host") ? decodeURIComponent(params.get("host")) : "");
+				setElementValue('cbid.shadowsocksr.' + sid + '.h2_path', params.get("path") ? decodeURIComponent(params.get("path")) : "");
 				break;
 			case "quic":
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.quic_guise')[0].value = params.get("headerType") || "none";
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.quic_security')[0].value = params.get("quicSecurity") || "none";
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.quic_key')[0].value = params.get("key") || "";
+				setElementValue('cbid.shadowsocksr.' + sid + '.quic_guise', params.get("headerType") || "none");
+				setElementValue('cbid.shadowsocksr.' + sid + '.quic_security', params.get("quicSecurity") || "none");
+				setElementValue('cbid.shadowsocksr.' + sid + '.quic_key', params.get("key") || "");
 				break;
 			case "grpc":
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.serviceName')[0].value = params.get("serviceName") || "";
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.grpc_mode')[0].value = params.get("mode") || "gun";
+				setElementValue('cbid.shadowsocksr.' + sid + '.serviceName', params.get("serviceName") || "");
+				setElementValue('cbid.shadowsocksr.' + sid + '.grpc_mode', params.get("mode") || "gun");
 				break;
 			case "tcp":
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.tcp_guise')[0].value = params.get("headerType") || "none";
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.tcp_guise')[0].dispatchEvent(event);
+				setElementValue('cbid.shadowsocksr.' + sid + '.tcp_guise', params.get("headerType") || "none");
+				dispatchEventIfExists('cbid.shadowsocksr.' + sid + '.tcp_guise', event);
 				if (params.get("headerType") === "http") {
-					document.getElementsByName('cbid.shadowsocksr.' + sid + '.http_host')[0].value = params.get("host") ? decodeURIComponent(params.get("host")) : "";
-					document.getElementsByName('cbid.shadowsocksr.' + sid + '.http_path')[0].value = params.get("path") ? decodeURIComponent(params.get("path")) : "";
+					setElementValue('cbid.shadowsocksr.' + sid + '.http_host', params.get("host") ? decodeURIComponent(params.get("host")) : "");
+					setElementValue('cbid.shadowsocksr.' + sid + '.http_path', params.get("path") ? decodeURIComponent(params.get("path")) : "");
 				}
+				break;
 			case "raw":
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.raw_guise')[0].value = params.get("headerType") || "none";
-				document.getElementsByName('cbid.shadowsocksr.' + sid + '.raw_guise')[0].dispatchEvent(event);
+				setElementValue('cbid.shadowsocksr.' + sid + '.raw_guise', params.get("headerType") || "none");
+				dispatchEventIfExists('cbid.shadowsocksr.' + sid + '.raw_guise', event);
 				if (params.get("headerType") === "http") {
-					document.getElementsByName('cbid.shadowsocksr.' + sid + '.http_host')[0].value = params.get("host") ? decodeURIComponent(params.get("host")) : "";
-					document.getElementsByName('cbid.shadowsocksr.' + sid + '.http_path')[0].value = params.get("path") ? decodeURIComponent(params.get("path")) : "";
+					setElementValue('cbid.shadowsocksr.' + sid + '.http_host', params.get("host") ? decodeURIComponent(params.get("host")) : "");
+					setElementValue('cbid.shadowsocksr.' + sid + '.http_path', params.get("path") ? decodeURIComponent(params.get("path")) : "");
 				}
 				break;
 			}

--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/ssrurl.htm
@@ -333,7 +333,7 @@ function import_ssr_url(btn, urlname, sid) {
 			setElementValue('cbid.shadowsocksr.' + sid + '.vmess_id', url.username);
 			setElementValue('cbid.shadowsocksr.' + sid + '.transport', 
 				params.get("type") === "http" ? "h2" : 
-				(params.get("type") === "raw" ? "raw" : 
+				(["tcp", "raw"].includes(params.get("type")) ? "raw" :  
 				(params.get("type") || "tcp"))
 			);
 			dispatchEventIfExists('cbid.shadowsocksr.' + sid + '.transport', event);
@@ -392,16 +392,9 @@ function import_ssr_url(btn, urlname, sid) {
 				setElementValue('cbid.shadowsocksr.' + sid + '.grpc_mode', params.get("mode") || "gun");
 				break;
 			case "tcp":
+			case "raw":
 				setElementValue('cbid.shadowsocksr.' + sid + '.tcp_guise', params.get("headerType") || "none");
 				dispatchEventIfExists('cbid.shadowsocksr.' + sid + '.tcp_guise', event);
-				if (params.get("headerType") === "http") {
-					setElementValue('cbid.shadowsocksr.' + sid + '.http_host', params.get("host") ? decodeURIComponent(params.get("host")) : "");
-					setElementValue('cbid.shadowsocksr.' + sid + '.http_path', params.get("path") ? decodeURIComponent(params.get("path")) : "");
-				}
-				break;
-			case "raw":
-				setElementValue('cbid.shadowsocksr.' + sid + '.raw_guise', params.get("headerType") || "none");
-				dispatchEventIfExists('cbid.shadowsocksr.' + sid + '.raw_guise', event);
 				if (params.get("headerType") === "http") {
 					setElementValue('cbid.shadowsocksr.' + sid + '.http_host', params.get("host") ? decodeURIComponent(params.get("host")) : "");
 					setElementValue('cbid.shadowsocksr.' + sid + '.http_path', params.get("path") ? decodeURIComponent(params.get("path")) : "");

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -220,22 +220,11 @@ end
 					fingerprint = server.fingerprint,
 					serverName = server.tls_host
 				} or nil,
-				tcpSettings = (server.transport == "tcp") and {
+				rawSettings = (server.transport == "raw" or server.transport == "tcp") and {
 					-- tcp
 					header = {
 						type = server.tcp_guise or "none",
 						request = (server.tcp_guise == "http") and {
-							-- request
-							path = {server.http_path} or {"/"},
-							headers = {Host = {server.http_host} or {}}
-						} or nil
-					}
-				} or nil,
-				rawSettings = (server.transport == "raw") and {
-					-- raw
-					header = {
-						type = server.raw_guise or "none",
-						request = (server.raw_guise == "http") and {
 							-- request
 							path = {server.http_path} or {"/"},
 							headers = {Host = {server.http_host} or {}}

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -28,7 +28,7 @@ function vmess_vless()
 						alterId = (server.v2ray_protocol == "vmess" or not server.v2ray_protocol) and tonumber(server.alter_id) or nil,
 						security = (server.v2ray_protocol == "vmess" or not server.v2ray_protocol) and server.security or nil,
 						encryption = (server.v2ray_protocol == "vless") and server.vless_encryption or nil,
-						flow = ((server.xtls == '1') or (server.tls == '1') or (server.reality == '1')) and server.tls_flow or nil
+						flow = (((server.xtls == '1') or (server.tls == '1') or (server.reality == '1')) and server.tls_flow ~= "none") and server.tls_flow or nil
 					}
 				}
 			}
@@ -220,26 +220,26 @@ end
 					fingerprint = server.fingerprint,
 					serverName = server.tls_host
 				} or nil,
-				tcpSettings = (server.transport == "tcp" and server.tcp_guise == "http") and {
+				tcpSettings = (server.transport == "tcp") and {
 					-- tcp
 					header = {
-						type = server.tcp_guise,
-						request = {
+						type = server.tcp_guise or "none",
+						request = (server.tcp_guise == "http") and {
 							-- request
 							path = {server.http_path} or {"/"},
 							headers = {Host = {server.http_host} or {}}
-						}
+						} or nil
 					}
 				} or nil,
-				rawSettings = (server.transport == "raw" and server.raw_guise == "http") and {
+				rawSettings = (server.transport == "raw") and {
 					-- raw
 					header = {
-						type = server.raw_guise,
-						request = {
+						type = server.raw_guise or "none",
+						request = (server.raw_guise == "http") and {
 							-- request
 							path = {server.http_path} or {"/"},
 							headers = {Host = {server.http_host} or {}}
-						}
+						} or nil
 					}
 				} or nil,
 				kcpSettings = (server.transport == "kcp") and {

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -400,15 +400,9 @@ local function processData(szType, content)
 		elseif result.transport == "grpc" then
 			result.serviceName = params.serviceName
 			result.grpc_mode = params.mode or "gun"
-		elseif result.transport == "tcp" then
+		elseif result.transport == "tcp" or result.transport == "raw" then
 			result.tcp_guise = params.headerType or "none"
 			if result.tcp_guise == "http" then
-				result.tcp_host = params.host and UrlDecode(params.host) or nil
-				result.tcp_path = params.path and UrlDecode(params.path) or nil
-			end
-		elseif result.transport == "raw" then
-			result.raw_guise = params.headerType or "none"
-			if result.raw_guise == "http" then
 				result.tcp_host = params.host and UrlDecode(params.host) or nil
 				result.tcp_path = params.path and UrlDecode(params.path) or nil
 			end

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -172,6 +172,9 @@ local function processData(szType, content)
 		result.v2ray_protocol = 'vmess'
 		result.server = info.add
 		result.server_port = info.port
+		if info.net == "tcp" then
+			info.net = "raw"
+		end
 		result.transport = info.net
 		result.alter_id = info.aid
 		result.vmess_id = info.id
@@ -194,7 +197,7 @@ local function processData(szType, content)
 			result.h2_host = info.host
 			result.h2_path = info.path
 		end
-		if info.net == 'tcp' then
+		if info.net == 'raw' or info.net == 'tcp' then
 			if info.type and info.type ~= "http" then
 				info.type = "none"
 			end


### PR DESCRIPTION
*** 在导入启用TLS或reality但无流量控制参数的节点时，默认仍导入flow，从而导致节点无法正常代理。同时tcp或raw传输协议配置应调整为无http和有http情况下的对应配置。

***  彻底修复导入 `Xray` 的 `vless` 各种传输协议配置时总是有个别参数无法按预期导入的bug。

***  合并`TCP`、`RAW`传输协议，不再区分旧版`TCP`和新版`RAW`，新旧版节点配置统一使用`RAW`传输协议。