### PR TITLE
luci-app-ssr-plus: status.lua: Add `restart Service` button.

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/status.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/status.lua
@@ -155,6 +155,14 @@ if nixio.fs.access("/usr/bin/kcptun-client") then
 	end
 end
 
+s = m:field(Button, "Restart", translate("Restart ShadowSocksR Plus+"))
+s.inputtitle = translate("Restart Service")
+s.inputstyle = "reload"
+s.write = function()
+	luci.sys.call("/etc/init.d/shadowsocksr restart >/dev/null 2>&1 &")
+	luci.http.redirect(luci.dispatcher.build_url("admin", "services", "shadowsocksr", "client"))
+end
+
 s = m:field(DummyValue, "google", translate("Google Connectivity"))
 s.value = translate("No Check")
 s.template = "shadowsocksr/check"
@@ -181,10 +189,10 @@ if uci:get_first("shadowsocksr", 'global', 'apple_optimization', '0') ~= '0' the
 end
 
 if uci:get_first("shadowsocksr", 'global', 'netflix_enable', '0') ~= '0' then
-s = m:field(DummyValue, "nfip_data", translate("Netflix IP Data"))
-s.rawhtml = true
-s.template = "shadowsocksr/refresh"
-s.value = nfip_count .. " " .. translate("Records")
+	s = m:field(DummyValue, "nfip_data", translate("Netflix IP Data"))
+	s.rawhtml = true
+	s.template = "shadowsocksr/refresh"
+	s.value = nfip_count .. " " .. translate("Records")
 end
 
 if uci:get_first("shadowsocksr", 'global', 'adblock', '0') == '1' then

--- a/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
@@ -377,6 +377,12 @@ msgstr "强制走代理"
 msgid "UDP Relay"
 msgstr "UDP 中继"
 
+msgid "Restart ShadowSocksR Plus+"
+msgstr "重启 ShadowSocksR Plus+"
+
+msgid "Restart Service"
+msgstr "重启服务"
+
 msgid "Google Connectivity"
 msgstr "【谷歌】连通性检查"
 


### PR DESCRIPTION
*** 用于手动更新数据库后直接重启以便应用新的数据库，解决需停止服务再启动服务的操作问题，当然也可以用于日常的重启需要。