### PR TITLE
luci-app-ssr-plus: Optimize and improve `socks` and add some features for Xray's `socks`.

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
@@ -1,5 +1,7 @@
+local m, s, o
 local uci = luci.model.uci.cursor()
 local server_table = {}
+local type_table = {}
 local function is_finded(e)
 	return luci.sys.exec('type -t -p "%s"' % e) ~= "" and true or false
 end
@@ -9,6 +11,9 @@ uci:foreach("shadowsocksr", "servers", function(s)
 		server_table[s[".name"]] = "[%s]:%s" % {string.upper(s.v2ray_protocol or s.type), s.alias}
 	elseif s.server and s.server_port then
 		server_table[s[".name"]] = "[%s]:%s:%s" % {string.upper(s.v2ray_protocol or s.type), s.server, s.server_port}
+	end
+	if s.type then
+		type_table[s[".name"]] = s.type
 	end
 end)
 
@@ -135,7 +140,7 @@ o.default = "https://raw.githubusercontent.com/neodevpro/neodevhost/master/lite_
 o:depends("adblock", "1")
 o.description = translate("Support AdGuardHome and DNSMASQ format list")
 
-o = s:option(Button, "reset", translate("Reset to defaults"))
+o = s:option(Button, "Reset", translate("Reset to defaults"))
 o.inputstyle = "reload"
 o.write = function()
 	luci.sys.call("/etc/init.d/shadowsocksr reset")
@@ -146,15 +151,82 @@ end
 s = m:section(TypedSection, "socks5_proxy", translate("Global SOCKS5 Proxy Server"))
 s.anonymous = true
 
-o = s:option(ListValue, "server", translate("Server"))
-o:value("nil", translate("Disable"))
-o:value("same", translate("Same as Global Server"))
-for _, key in pairs(key_table) do
-	o:value(key, server_table[key])
-end
-o.default = "nil"
+-- Enable/Disable Option
+o = s:option(Flag, "enabled", translate("Enable"))
+o.default = 0
 o.rmempty = false
 
+-- Server Selection
+o = s:option(ListValue, "server", translate("Server"))
+o:value("same", translate("Same as Global Server"))
+for _, key in pairs(key_table) do
+    o:value(key, server_table[key])
+end
+o.default = "same"
+o.rmempty = false
+
+-- Dynamic value handling based on enabled/disabled state
+o.cfgvalue = function(self, section)
+    local enabled = m:get(section, "enabled")
+    if enabled == "0" then
+        return m:get(section, "old_server") or "same"
+    end
+    return Value.cfgvalue(self, section) or "same" -- Default to `same` when enabled
+end
+
+o.write = function(self, section, value)
+    local enabled = m:get(section, "enabled")
+    if enabled == "0" then
+        local old_server = Value.cfgvalue(self, section) or "same"
+        if old_server ~= "nil" then
+            m:set(section, "old_server", old_server)
+        end
+        m:set(section, "server", "nil")
+    else
+        m:del(section, "old_server")
+        -- Write the value normally when enabled
+        Value.write(self, section, value)
+    end
+end
+
+-- Socks Auth
+if is_finded("xray") then
+o = s:option(ListValue, "socks5_auth", translate("Socks5 Auth Mode"), translate("Socks protocol auth methods, default:noauth."))
+o.default = "noauth"
+o:value("noauth", "NOAUTH")
+o:value("password", "PASSWORD")
+o.rmempty = true
+for key, server_type in pairs(type_table) do
+    if server_type == "v2ray" then
+        -- 如果服务器类型是 v2ray，则设置依赖项显示
+        o:depends("server", key)
+    end
+end
+
+-- Socks User
+o = s:option(Value, "socks5_user", translate("Socks5 User"), translate("Only when auth is password valid, Mandatory."))
+o.rmempty = true
+o:depends("socks5_auth", "password")
+
+-- Socks Password
+o = s:option(Value, "socks5_pass", translate("Socks5 Password"), translate("Only when auth is password valid, Not mandatory."))
+o.password = true
+o.rmempty = true
+o:depends("socks5_auth", "password")
+
+-- Socks Mixed
+o = s:option(Flag, "socks5_mixed", translate("Enabled Mixed"), translate("Mixed as an alias of socks, default:Enabled."))
+o.default = "1"
+o.rmempty = false
+for key, server_type in pairs(type_table) do
+    if server_type == "v2ray" then
+        -- 如果服务器类型是 v2ray，则设置依赖项显示
+        o:depends("server", key)
+    end
+end
+end
+
+-- Local Port
 o = s:option(Value, "local_port", translate("Local Port"))
 o.datatype = "port"
 o.default = 1080
@@ -171,6 +243,7 @@ o.default = 0
 o = s:option(ListValue, "fragment_packets", translate("Fragment Packets"), translate("\"1-3\" is for segmentation at TCP layer, applying to the beginning 1 to 3 data writes by the client. \"tlshello\" is for TLS client hello packet fragmentation."))
 o.default = "tlshello"
 o:value("tlshello", "tlshello")
+o:value("1-1", "1-1")
 o:value("1-2", "1-2")
 o:value("1-3", "1-3")
 o:value("1-5", "1-5")

--- a/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
@@ -892,6 +892,30 @@ msgstr "本机服务端"
 msgid "Global SOCKS5 Proxy Server"
 msgstr "SOCKS5 代理服务端（全局）"
 
+msgid "Socks5 Auth Mode"
+msgstr "Socks5 认证方式"
+
+msgid "Socks protocol auth methods, default:noauth."
+msgstr "Socks 协议的认证方式，默认值：noauth。"
+
+msgid "Socks5 User"
+msgstr "Socks5 用户名"
+
+msgid "Only when auth is password valid, Mandatory."
+msgstr "仅当 auth 为 password 时有效，必填。"
+
+msgid "Socks5 Password"
+msgstr "Socks5 密码"
+
+msgid "Only when auth is password valid, Not mandatory."
+msgstr "仅当 auth 为 password 时有效，非必填。"
+
+msgid "Enabled Mixed"
+msgstr "启用 Mixed"
+
+msgid "Mixed as an alias of socks, default:Enabled."
+msgstr "Mixed 作为 SOCKS 的别名，默认：启用。"
+
 msgid "Xray Fragment Settings"
 msgstr "Xray 分片设置"
 

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -12,6 +12,7 @@ local chain = arg[5] or "0"
 local chain_local_port = string.split(chain, "/")[2] or "0"
 
 local server = ucursor:get_all("shadowsocksr", server_section)
+local socks_server = ucursor:get_all("shadowsocksr", "@socks5_proxy[0]") or {}
 local xray_fragment = ucursor:get_all("shadowsocksr", "@global_xray_fragment[0]") or {}
 local xray_noise = ucursor:get_all("shadowsocksr", "@xray_noise_packets[0]") or {}
 local outbound_settings = nil
@@ -180,10 +181,20 @@ end
 	-- 检查是否启用 socks 代理
 if proto:find("tcp") and socks_port ~= "0" then
     table.insert(Xray.inbounds, {
-	-- socks
+        -- socks
         protocol = "socks",
         port = tonumber(socks_port),
-        settings = {auth = "noauth", udp = true}
+        settings = {
+			auth = socks_server.socks5_auth,
+			udp = true,
+			mixed = (socks_server.socks5_mixed == '1') and true or false,
+			accounts = (socks_server.socks5_auth ~= "noauth") and {
+				{
+					user = socks_server.socks5_user,
+					pass = socks_server.socks5_pass
+				}
+			} or nil
+		}
     })
 end
 


### PR DESCRIPTION
优化和改进的是：将服务器中的停用剥离，改为在界面中使用 **`启用`** 按钮处理（即：勾选时 **`启用`**，不勾选时 **`停用`** ），服务器中正常展示服务器中的节点信息。同时停用时仍默认为设置的服务器节点，以便后续继续使用，如需更改为其他节点，下拉选择并启用即可。
**Xray的功能新增见：**
https://github.com/XTLS/Xray-core/commit/5af90684c44d88036b99fbd441f3ad96847992a2
https://xtls.github.io/config/inbounds/socks.html#inboundconfigurationobject
### **效果图：**
### **Xray的socks界面：**
![image](https://github.com/user-attachments/assets/b6008c5d-b42b-48a9-9b32-c6b27641e3b4)

![image](https://github.com/user-attachments/assets/1a4acd33-6bd0-46e1-88bf-aa2bd3ec725e)
### **其他协议的socks界面：**
![image](https://github.com/user-attachments/assets/faa7320e-f9ab-4115-9b68-e94cec2538f0)

![image](https://github.com/user-attachments/assets/675eb8c5-56d5-458f-8406-d30882410a5e)


