### PR TITLE
luci-app-ssr-plus: Fix when `SOCKS` enable password auth `Netflix` shunt failed issue.

### DIFF
--- a/luci-app-ssr-plus/Makefile
+++ b/luci-app-ssr-plus/Makefile
@@ -32,7 +32,7 @@ PKG_CONFIG_DEPENDS:= \
 LUCI_TITLE:=SS/SSR/V2Ray/Trojan/NaiveProxy/Tuic/ShadowTLS/Hysteria/Socks5/Tun LuCI interface
 LUCI_PKGARCH:=all
 LUCI_DEPENDS:= \
-	+coreutils +coreutils-base64 +dns2socks +dns2tcp +dnsmasq-full +@PACKAGE_dnsmasq_full_ipset +ipset +kmod-ipt-nat \
+	+coreutils +coreutils-base64 +dns2socks +dns2tcp +dnsmasq-full +@PACKAGE_dnsmasq_full_ipset +ipset +kmod-ipt-nat +jq \
 	+ip-full +iptables +iptables-mod-tproxy +lua +lua-neturl +libuci-lua +microsocks \
 	+tcping +resolveip +shadowsocksr-libev-ssr-check +uclient-fetch \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_libustream-mbedtls:libustream-mbedtls \

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -533,6 +533,31 @@ shunt_dns_command() {
 	esac
 }
 
+shunt_dns_config_file_port() {
+    if [ "$LOCAL_SERVER" == "$SHUNT_SERVER" ]; then
+        # NetFlix 和 全局socks 节点相同
+        if [ "$(uci_get_by_type socks5_proxy socks5_auth nil)" != "noauth" ]; then
+            # 全局socks 有密码，NetFlix 不能使用 auth 验证，需更换为新端口并使用无密码的 socks 配置用于分流
+            # 新增NetFlix dns 使用端口
+            local port=$tmp_shunt_local_port
+                   jq --arg port "$port" '.inbounds |= .[0:1] + [{"protocol":"socks","port":($port | tonumber),"settings":{"udp":true,"auth":"noauth"}}] + .[1:]' "$shunt_config_file" > "$shunt_config_file.tmp" && mv "$shunt_config_file.tmp" $shunt_config_file
+            echo "$port"  # 返回端口号
+            return 0  # 成功返回
+        fi
+    else
+        # NetFlix 和 全局 socks 节点不相同
+        if [ "$(uci_get_by_type socks5_proxy socks5_auth nil)" != "noauth" ]; then
+            # 全局socks 有密码，NetFlix不能使用auth验证，需设置为无密码的socks配置用于分流
+            # 删除 NetFlix dns 端口密码验证
+            sed -i -e 's/"auth"\s*:\s*"password"/\"auth\": \"noauth\"/g' \
+                   -e '/"accounts": \[/,/\]/d' $shunt_config_file
+        fi
+    fi
+    # 使用传入的端口
+    echo "$1"  # 返回传入的端口号
+    return 0  # 成功返回
+}
+
 start_shunt() {
 	local type=$(uci_get_by_name $SHUNT_SERVER type)
 	case "$type" in
@@ -552,6 +577,14 @@ start_shunt() {
 	v2ray)
 		local tmp_port=${tmp_local_port:-$tmp_shunt_local_port}
 		gen_config_file $SHUNT_SERVER $type 3 $tmp_shunt_port $tmp_port
+		# 处理配置文件中的 NetFlix 端口
+		if [ "$LOCAL_SERVER" == "$SHUNT_SERVER" ]; then
+			# NetFlix 和 全局socks 节点相同
+			tmp_port=$(shunt_dns_config_file_port "$tmp_port")
+		else
+			# NetFlix 和 全局 socks 节点不相同
+			shunt_dns_config_file_port "$tmp_port"
+		fi
 		ln_start_bin $(first_type xray v2ray) v2ray run -c $shunt_config_file
 		shunt_dns_command $tmp_port
 		echolog "shunt:$($(first_type xray v2ray) version | head -1) Started!"


### PR DESCRIPTION
目前 V2ray 等相关节点在开启分流后，不能使用socks5全局的password，会导致分流失败，此PR已修复。

原打算将奈飞分流使用的dns可以认证（dns2socks支持身份认证），但因mosdns不支持，没办法只能改为全部不需认证。

感谢TG群友“H”的贡献。