### PR TITLE
luci-app-ssr-plus: Add `SS` plug custom Settings.

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client-config.lua
@@ -296,8 +296,13 @@ end
 if is_finded("xray-plugin") then
 	o:value("xray-plugin", translate("xray-plugin"))
 end
+o:value("custom", translate("Custom"))
 o.rmempty = true
 o:depends({type = "ss", enable_plugin = true})
+
+o = s:option(Value, "custom_plugin", translate("Custom Plugin Path"))
+o.placeholder = "/path/to/custom-plugin"
+o:depends({plugin = "custom"})
 
 o = s:option(Value, "plugin_opts", translate("Plugin Opts"))
 o.rmempty = true

--- a/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
@@ -849,6 +849,12 @@ msgstr "启用插件"
 msgid "Plugin"
 msgstr "插件"
 
+msgid "Custom"
+msgstr "自定义"
+
+msgid "Custom Plugin Path"
+msgstr "自定义插件路径"
+
 msgid "Plugin Opts"
 msgstr "插件参数"
 

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -580,7 +580,11 @@ function config:handleIndex(index)
 		ss = function()
 			ss.protocol = socks_port
 			if server.enable_plugin == "1" and server.plugin and server.plugin ~= "none" then
-				ss.plugin = server.plugin
+				if server.plugin == "custom" then
+					ss.plugin = server.custom_plugin
+				else
+					ss.plugin = server.plugin
+				end
 				ss.plugin_opts = server.plugin_opts or nil
 			end
 			print(json.stringify(ss, 1))


### PR DESCRIPTION
1、如ssrp不存在对应VPS服务器的插件时（比如：服务器使用的是Cloak插件，但ssrp没有该插件），可通过自定义设置插件路径和参数，以便SSRP能使用节点正常代理。
2、不选择自定义时，页面不显示自定义插件路径。

**效果图：**

![image](https://github.com/user-attachments/assets/5ef9ca98-fb3b-4a1f-91ee-0903265eb95f)
![image](https://github.com/user-attachments/assets/77a5242d-7adf-4b19-a617-edc5b99956e7)
