### PR TITLE
luci-app-ssr-plus: Fix disable shunt mode `Netflix` list domain name unavailable.

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
@@ -66,7 +66,7 @@ o:value("https://fastly.jsdelivr.net/gh/gaoyifan/china-operator-ip@ip-lists/chin
 o.default = "https://ispip.clang.cn/all_cn.txt"
 
 o = s:option(Flag, "netflix_enable", translate("Enable Netflix Mode"))
-o.description = translate("Disable shunt mode before, Please must first disable shunt node.")
+o.description = translate("When disabled shunt mode, will same time stopped shunt service.")
 o.rmempty = false
 
 o = s:option(Value, "nfip_url", translate("nfip_url"))

--- a/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
@@ -1209,8 +1209,8 @@ msgstr "应用"
 msgid "Enable Netflix Mode"
 msgstr "启用 Netflix 分流模式"
 
-msgid "Disable shunt mode before, Please must first disable shunt node."
-msgstr "停用分流模式之前，请务必先停用分流节点。"
+msgid "When disabled shunt mode, will same time stopped shunt service."
+msgstr "当停用分流模式时，将同时停止分流服务。"
 
 msgid "TUIC User UUID"
 msgstr "TUIC 用户 uuid"


### PR DESCRIPTION
同时优化代码使用while方式读取列表文件 防止 /etc/ssrplus/ 目录下的 black.list white.list deny.list 等2个或多个文件一行中存在空格 比如:# abc.com 而丢失：server。



感谢TG群友“H”的贡献。