### PR TITLE
luci-app-ssr-plus: Add `chinadns-ng` proxy parse.

### DIFF
--- a/luci-app-ssr-plus/Makefile
+++ b/luci-app-ssr-plus/Makefile
@@ -11,6 +11,7 @@ PKG_CONFIG_DEPENDS:= \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_ChinaDNS_NG \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_DNS2SOCKS \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_DNS2SOCKS_RUST \
+	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_DNS2TCP \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_DNSPROXY \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_MosDNS \
 	CONFIG_PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria \
@@ -35,7 +36,7 @@ PKG_CONFIG_DEPENDS:= \
 LUCI_TITLE:=SS/SSR/V2Ray/Trojan/NaiveProxy/Tuic/ShadowTLS/Hysteria/Socks5/Tun LuCI interface
 LUCI_PKGARCH:=all
 LUCI_DEPENDS:= \
-	+coreutils +coreutils-base64 +dns2tcp +dnsmasq-full +@PACKAGE_dnsmasq_full_ipset +ipset +kmod-ipt-nat +jq \
+	+coreutils +coreutils-base64 +dnsmasq-full +@PACKAGE_dnsmasq_full_ipset +ipset +kmod-ipt-nat +jq \
 	+ip-full +iptables +iptables-mod-tproxy +lua +lua-neturl +libuci-lua +microsocks \
 	+tcping +resolveip +shadowsocksr-libev-ssr-check +wget-ssl \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_V2ray:curl \
@@ -45,6 +46,7 @@ LUCI_DEPENDS:= \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_ChinaDNS_NG:chinadns-ng \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_DNS2SOCKS:dns2socks \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_DNS2SOCKS_RUST:dns2socks-rust \
+	+PACKAGE_$(PKG_NAME)_INCLUDE_DNS2TCP:dns2tcp \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_DNSPROXY:dnsproxy \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_MosDNS:mosdns \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Hysteria:hysteria \
@@ -130,6 +132,10 @@ config PACKAGE_$(PKG_NAME)_INCLUDE_DNS2SOCKS
 
 config PACKAGE_$(PKG_NAME)_INCLUDE_DNS2SOCKS_RUST
 	bool "Include DNS2socks-Rust"
+	default n
+
+config PACKAGE_$(PKG_NAME)_INCLUDE_DNS2TCP
+	bool "Include DNS2tcp"
 	default n
 
 config PACKAGE_$(PKG_NAME)_INCLUDE_DNSPROXY

--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
@@ -107,6 +107,9 @@ end
 if is_finded("dnsproxy") then
 	o:value("4", translate("Use DNSPROXY query and cache"))
 end
+if is_finded("chinadns-ng") then
+	o:value("5", translate("Use ChinaDNS-NG query and cache"))
+end
 o:depends("netflix_enable", "1")
 o.default = 1
 
@@ -188,6 +191,35 @@ if is_finded("dnsproxy") then
 	o:depends("shunt_parse_method", "parse_file")
 	o.rmempty = false
 	o.default = "1"
+end
+
+if is_finded("chinadns-ng") then
+	o = s:option(Value, "chinadns_ng_shunt_dnsserver", translate("Anti-pollution DNS Server For Shunt Mode"))
+	o:value("8.8.4.4:53", translate("Google Public DNS (8.8.4.4)"))
+	o:value("8.8.8.8:53", translate("Google Public DNS (8.8.8.8)"))
+	o:value("208.67.222.222:53", translate("OpenDNS (208.67.222.222)"))
+	o:value("208.67.220.220:53", translate("OpenDNS (208.67.220.220)"))
+	o:value("209.244.0.3:53", translate("Level 3 Public DNS (209.244.0.3)"))
+	o:value("209.244.0.4:53", translate("Level 3 Public DNS (209.244.0.4)"))
+	o:value("4.2.2.1:53", translate("Level 3 Public DNS (4.2.2.1)"))
+	o:value("4.2.2.2:53", translate("Level 3 Public DNS (4.2.2.2)"))
+	o:value("4.2.2.3:53", translate("Level 3 Public DNS (4.2.2.3)"))
+	o:value("4.2.2.4:53", translate("Level 3 Public DNS (4.2.2.4)"))
+	o:value("1.1.1.1:53", translate("Cloudflare DNS (1.1.1.1)"))
+	o:depends("shunt_dns_mode", "5")
+	o.description = translate(
+    	"<ul>" ..
+    	"<li>" .. translate("Custom DNS Server format as IP:PORT (default: 8.8.4.4:53)") .. "</li>" .. 
+    	"<li>" .. translate("Muitiple DNS server can saperate with ','") .. "</li>" ..
+    	"</ul>"
+	)
+
+	o = s:option(ListValue, "chinadns_ng_shunt_proto", translate("ChinaDNS-NG shunt query protocol"))
+	o:value("none", translate("UDP/TCP upstream"))
+	o:value("tcp", translate("TCP upstream"))
+	o:value("udp", translate("UDP upstream"))
+	o:value("tls", translate("DoT upstream (Need use wolfssl version)"))
+	o:depends("shunt_dns_mode", "5")
 end
 
 o = s:option(Flag, "apple_optimization", translate("Apple domains optimization"), translate("For Apple domains equipped with Chinese mainland CDN, always responsive to Chinese CDN IP addresses"))

--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client.lua
@@ -111,7 +111,9 @@ cp.placeholder = "e.g., 80,443,8080"
 o.default = 1
 
 o = s:option(ListValue, "pdnsd_enable", translate("Resolve Dns Mode"))
-o:value("1", translate("Use DNS2TCP query"))
+if is_finded("dns2tcp") then
+	o:value("1", translate("Use DNS2TCP query"))
+end
 if is_finded("dns2socks") then
 	o:value("2", translate("Use DNS2SOCKS query and cache"))
 end
@@ -123,6 +125,9 @@ if is_finded("mosdns") then
 end
 if is_finded("dnsproxy") then
 	o:value("5", translate("Use DNSPROXY query and cache"))
+end
+if is_finded("chinadns-ng") then
+	o:value("6", translate("Use ChinaDNS-NG query and cache"))
 end
 o:value("0", translate("Use Local DNS Service listen port 5335"))
 o.default = 1
@@ -212,6 +217,33 @@ if is_finded("dnsproxy") then
 end
 
 if is_finded("chinadns-ng") then
+	o = s:option(Value, "chinadns_ng_tunnel_forward", translate("Anti-pollution DNS Server"))
+	o:value("8.8.4.4:53", translate("Google Public DNS (8.8.4.4)"))
+	o:value("8.8.8.8:53", translate("Google Public DNS (8.8.8.8)"))
+	o:value("208.67.222.222:53", translate("OpenDNS (208.67.222.222)"))
+	o:value("208.67.220.220:53", translate("OpenDNS (208.67.220.220)"))
+	o:value("209.244.0.3:53", translate("Level 3 Public DNS (209.244.0.3)"))
+	o:value("209.244.0.4:53", translate("Level 3 Public DNS (209.244.0.4)"))
+	o:value("4.2.2.1:53", translate("Level 3 Public DNS (4.2.2.1)"))
+	o:value("4.2.2.2:53", translate("Level 3 Public DNS (4.2.2.2)"))
+	o:value("4.2.2.3:53", translate("Level 3 Public DNS (4.2.2.3)"))
+	o:value("4.2.2.4:53", translate("Level 3 Public DNS (4.2.2.4)"))
+	o:value("1.1.1.1:53", translate("Cloudflare DNS (1.1.1.1)"))
+	o:depends("pdnsd_enable", "6")
+	o.description = translate(
+    	"<ul>" ..
+    	"<li>" .. translate("Custom DNS Server format as IP:PORT (default: 8.8.4.4:53)") .. "</li>" .. 
+    	"<li>" .. translate("Muitiple DNS server can saperate with ','") .. "</li>" ..
+    	"</ul>"
+	)
+
+	o = s:option(ListValue, "chinadns_ng_proto", translate("ChinaDNS-NG query protocol"))
+	o:value("none", translate("UDP/TCP upstream"))
+	o:value("tcp", translate("TCP upstream"))
+	o:value("udp", translate("UDP upstream"))
+	o:value("tls", translate("DoT upstream (Need use wolfssl version)"))
+	o:depends("pdnsd_enable", "6")
+
 	o = s:option(Value, "chinadns_forward", translate("Domestic DNS Server"))
 	o:value("", translate("Disable ChinaDNS-NG"))
 	o:value("wan", translate("Use DNS from WAN"))
@@ -226,6 +258,8 @@ if is_finded("chinadns-ng") then
 	o:depends({pdnsd_enable = "1", run_mode = "router"})
 	o:depends({pdnsd_enable = "2", run_mode = "router"})
 	o:depends({pdnsd_enable = "3", run_mode = "router"})
+	o:depends({pdnsd_enable = "5", run_mode = "router"})
+	o:depends({pdnsd_enable = "6", run_mode = "router"})
 	o.description = translate("Custom DNS Server format as IP:PORT (default: disabled)")
 	o.validate = function(self, value, section)
 		if (section and value) then

--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/status.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/status.lua
@@ -92,7 +92,11 @@ if Process_list:find("ssr.server") then
 	server_run = 1
 end
 
-if Process_list:find("ssrplus/bin/dns2tcp") or Process_list:find("ssrplus/bin/mosdns") or Process_list:find("dnsproxy.*127.0.0.1.*5335") or (Process_list:find("ssrplus.dns") and Process_list:find("dns2socks*.*127.0.0.1.*127.0.0.1.5335")) then
+if  Process_list:find("ssrplus/bin/dns2tcp") or
+    Process_list:find("ssrplus/bin/mosdns") or
+    Process_list:find("dnsproxy.*127.0.0.1.*5335") or
+    Process_list:find("chinadns.*127.0.0.1.*5335") or
+    (Process_list:find("ssrplus.dns") and Process_list:find("dns2socks.*127.0.0.1.*127.0.0.1.5335")) then
 	pdnsd_run = 1
 end
 

--- a/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
@@ -612,6 +612,27 @@ msgstr "访问国外域名 DNS 服务器"
 msgid "Custom DNS Server format as IP:PORT (default: 8.8.4.4:53)"
 msgstr "格式为 IP:Port（默认：8.8.4.4:53）"
 
+msgid "Muitiple DNS server can saperate with ','"
+msgstr "多个上游 DNS 服务器请用 ',' 分隔（注意用英文逗号)"
+
+msgid "ChinaDNS-NG query protocol"
+msgstr "ChinaDNS-NG 查询协议"
+
+msgid "UDP/TCP upstream"
+msgstr "UDP/TCP 上游"
+
+msgid "TCP upstream"
+msgstr "TCP 上游"
+
+msgid "UDP upstream"
+msgstr "UDP 上游"
+
+msgid "DoT upstream (Need use wolfssl version)"
+msgstr "DoT 上游（需使用 wolfssl 版本）"
+
+msgid "ChinaDNS-NG shunt query protocol"
+msgstr "ChinaDNS-NG 分流查询协议"
+
 msgid "Use DNS2TCP query"
 msgstr "使用 DNS2TCP 查询"
 
@@ -626,6 +647,9 @@ msgstr "使用 MOSDNS 查询 (不支持海外用户回国模式)"
 
 msgid "Use DNSPROXY query and cache"
 msgstr "使用 DNSPROXY 查询并缓存"
+
+msgid "Use ChinaDNS-NG query and cache"
+msgstr "使用 ChinaDNS-NG 查询并缓存"
 
 msgid "Select DNS parse Mode"
 msgstr "选择 DNS 解析方式"

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -203,6 +203,8 @@ start_dns() {
 	local dnsproxy_dnsserver="$(uci_get_by_type global parse_method)"
 	if [ -n "$dnsproxy_dnsserver" ] && [ "$dnsproxy_dnsserver" != "parse_file" ]; then
 		dnsserver="$(uci_get_by_type global dnsproxy_tunnel_forward 8.8.4.4:53)"
+	elif [ -n "$ssrplus_dns" ] && [ "$ssrplus_dns" = "6" ]; then
+		dnsserver="$(uci_get_by_type global chinadns_ng_tunnel_forward 8.8.4.4:53)"
 	else
 		dnsserver="$(uci_get_by_type global tunnel_forward 8.8.4.4:53)"
 	fi
@@ -306,6 +308,38 @@ start_dns() {
 			fi
 			echolog "DNSPROXY query and cache Started!"
 			pdnsd_enable_flag=5
+			;;
+		6)
+			local chinadns_ng_proto="$(uci_get_by_type global chinadns_ng_proto)"
+			local chinadns_ng_dns=""
+			# 遍历每个 DNS 服务器
+			IFS=','  # 设置分隔符为逗号
+			for chinadns_ng_server in $dnsserver; do
+				# 处理单个服务器地址
+				local chinadns_ng_ip="${chinadns_ng_server%%:*}"
+				local chinadns_ng_port="${chinadns_ng_server##*:}"
+				[ "$chinadns_ng_ip" = "$chinadns_ng_port" ] && chinadns_ng_port="53"
+				chinadns_ng_tls_port="853"
+				# 根据协议类型格式化服务器地址
+				case "$chinadns_ng_proto" in
+					"none")
+            					chinadns_ng_server="${chinadns_ng_ip}#${chinadns_ng_port}"
+            					;;
+					"tls")
+            					chinadns_ng_server="${chinadns_ng_proto}://${chinadns_ng_ip}#${chinadns_ng_tls_port}"
+            					;;
+					*)
+            					chinadns_ng_server="${chinadns_ng_proto}://${chinadns_ng_ip}#${chinadns_ng_port}"
+            					;;
+				esac
+				# 添加到参数列表
+				chinadns_ng_dns="${chinadns_ng_dns} -t ${chinadns_ng_server}"
+			done
+			unset IFS  # 恢复默认分隔符
+			dnsserver="$chinadns_ng_dns"
+			ln_start_bin $(first_type chinadns-ng) chinadns-ng -b 127.0.0.1 -l $tmp_dns_port -l $dns_port -p 3 -d gfw $dnsserver -N --filter-qtype 64,65 -f -r --cache 4096 --cache-stale 86400 --cache-refresh 20
+			echolog "ChinaDNS-NG query and cache Started!"
+			pdnsd_enable_flag=6
 			;;
 		esac
 
@@ -592,6 +626,8 @@ shunt_dns_command() {
 	local shunt_dnsproxy_dnsserver="$(uci_get_by_type global shunt_parse_method)"
 	if [ -n "$shunt_dnsproxy_dnsserver" ] && [ "$shunt_dnsproxy_dnsserver" != "parse_file" ]; then
 		shunt_dnsserver="$(uci_get_by_type global dnsproxy_shunt_forward 8.8.4.4:53)"
+	elif [ -n "shunt_dns_mode" ] && [ "$shunt_dns_mode" = "5" ]; then
+		shunt_dnsserver="$(uci_get_by_type global chinadns_ng_shunt_dnsserver 8.8.4.4:53)"
 	else
 		shunt_dnsserver="$(uci_get_by_type global shunt_dnsserver 8.8.4.4:53)"
 	fi
@@ -678,6 +714,38 @@ shunt_dns_command() {
 			fi
 		fi
 		echolog "DNSPROXY shunt query and cache Started!"
+		;;
+	5)
+		local chinadns_ng_shunt_proto="$(uci_get_by_type global chinadns_ng_shunt_proto)"
+		local chinadns_ng_shunt_dns=""
+		# 遍历每个 DNS 服务器
+		IFS=','  # 设置分隔符为逗号
+		for chinadns_ng_shunt_server in $shunt_dnsserver; do
+			# 处理单个服务器地址
+			local chinadns_ng_shunt_ip="${chinadns_ng_shunt_server%%:*}"
+			local chinadns_ng_shunt_port="${chinadns_ng_shunt_server##*:}"
+			[ "$chinadns_ng_shunt_ip" = "$chinadns_ng_shunt_port" ] && chinadns_ng_shunt_port="53"
+			chinadns_ng_shunt_tls_port="853"
+			# 根据协议类型格式化服务器地址
+			case "$chinadns_ng_shunt_proto" in
+				"none")
+            				chinadns_ng_shunt_server="${chinadns_ng_shunt_ip}#${chinadns_ng_shunt_port}"
+            				;;
+				"tls")
+            				chinadns_ng_shunt_server="${chinadns_ng_shunt_proto}://${chinadns_ng_shunt_ip}#${chinadns_ng_shunt_tls_port}"
+            				;;
+				*)
+            				chinadns_ng_shunt_server="${chinadns_ng_shunt_proto}://${chinadns_ng_shunt_ip}#${chinadns_ng_shunt_port}"
+            				;;
+			esac
+			# 添加到参数列表
+			chinadns_ng_shunt_dns="${chinadns_ng_shunt_dns} -t ${chinadns_ng_shunt_server}"
+		done
+		unset IFS  # 恢复默认分隔符
+		shunt_dnsserver="$chinadns_ng_shunt_dns"
+		# 启动 chinadns-ng
+		ln_start_bin $(first_type chinadns-ng) chinadns-ng -b 127.0.0.1 -l $tmp_port -l $tmp_shunt_dns_port -p 3 -d gfw $shunt_dnsserver -N --filter-qtype 64,65 -f -r --cache 4096 --cache-stale 86400 --cache-refresh 20
+		echolog "ChinaDNS-NG shunt query and cache Started!"
 		;;
 	esac
 }

--- a/luci-app-ssr-plus/root/usr/bin/ssr-monitor
+++ b/luci-app-ssr-plus/root/usr/bin/ssr-monitor
@@ -95,7 +95,7 @@ while [ "1" == "1" ]; do #死循环
 	#dns2socks
 	elif [ "$pdnsd_process" -eq 2 ]; then
 		icount=$(busybox ps -w | grep -e ssrplus-dns -e "dns2socks 127.0.0.1 $tmp_dns_port" | grep -v grep | wc -l)
-		if [ "$icount" -lt 2 ]; then #如果进程挂掉就重启它
+		if [ "$icount" -lt 1 ]; then #如果进程挂掉就重启它
 			logger -t "$NAME" "dns2socks $dnsserver tunnel error.restart!"
 			echolog "dns2socks $dnsserver tunnel error.restart!"
 			dnsserver=$(uci_get_by_type global tunnel_forward 8.8.4.4:53)
@@ -107,7 +107,7 @@ while [ "1" == "1" ]; do #死循环
 	#dns2socks-rust
 	elif [ "$pdnsd_process" -eq 3 ]; then
 		icount=$(busybox ps -w | grep -e ssrplus-dns -e "dns2socks-rust -s socks5://127.0.0.1 $tmp_dns_port" | grep -v grep | wc -l)
-		if [ "$icount" -lt 2 ]; then #如果进程挂掉就重启它
+		if [ "$icount" -lt 1 ]; then #如果进程挂掉就重启它
 			logger -t "$NAME" "dns2socks-rust $dnsserver tunnel error.restart!"
 			echolog "dns2socks-rust $dnsserver tunnel error.restart!"
 			dnsserver=$(uci_get_by_type global tunnel_forward 8.8.4.4:53)
@@ -127,15 +127,15 @@ while [ "1" == "1" ]; do #死循环
 			ln_start_bin $(first_type mosdns) mosdns start -c /etc/mosdns/config.yaml
 	#dnsproxy
 	elif [ "$pdnsd_process" -eq 5 ]; then
-		icount=$(busybox ps -w | grep -e ssrplus-dns -e "dnsproxy -l 127.0.0.1 -p $tmp_port" | grep -v grep | wc -l)
-		if [ "$icount" -lt 2 ]; then #如果进程挂掉就重启它
+		icount=$(busybox ps -w | grep -e ssrplus-dns -e "dnsproxy -l 127.0.0.1 -p $tmp_dns_port" | grep -v grep | wc -l)
+		if [ "$icount" -lt 1 ]; then #如果进程挂掉就重启它
 			logger -t "$NAME" "dnsproxy $dnsserver tunnel error.restart!"
 			echolog "dnsproxy $dnsserver tunnel error.restart!"
 			local dnsproxy_dnsserver="$(uci_get_by_type global parse_method)"
 			if [ -n "$dnsproxy_dnsserver" ] && [ "$dnsproxy_dnsserver" != "parse_file" ]; then
 				dnsserver="$(uci_get_by_type global dnsproxy_tunnel_forward 8.8.4.4:53)"
 			fi
-			kill -9 $(busybox ps -w | grep "dnsproxy -l 127.0.0.1 -p $tmp_port" | grep -v grep | awk '{print $1}') >/dev/null 2>&1
+			kill -9 $(busybox ps -w | grep "dnsproxy -l 127.0.0.1 -p $tmp_dns_port" | grep -v grep | awk '{print $1}') >/dev/null 2>&1
 			dnsproxy_ipv6="$(uci_get_by_type global dnsproxy_ipv6)"
 				disabled_ipv6="--ipv6-disabled"
 			fi
@@ -191,8 +191,41 @@ while [ "1" == "1" ]; do #死循环
 				fi
 			fi
 		fi
+	#chinadns-ng(proxy)
+	elif [ "$pdnsd_process" -eq 6 ]; then
+		icount=$(busybox ps -w | grep -e ssrplus-dns -e "chinadns-ng -b 127.0.0.1 -l $tmp_dns_port" | grep -v grep | wc -l)
+		if [ "$icount" -lt 1 ]; then #如果进程挂掉就重启它
+			logger -t "$NAME" "chinadns-ng $dnsserver tunnel error.restart!"
+			echolog "chinadns-ng $dnsserver tunnel error.restart!"
+			dnsserver=$(uci_get_by_type global chinadns_ng_tunnel_forward 8.8.4.4:53)
+			kill -9 $(busybox ps -w | grep "chinadns-ng -b 127.0.0.1 -l $tmp_dns_port" | grep -v grep | awk '{print $1}') >/dev/null 2>&1
+			local chinadns_ng_proto="$(uci_get_by_type global chinadns_ng_proto)"
+			local chinadns_ng_dns=""
+			IFS=','
+			for chinadns_ng_server in $dnsserver; do
+				local chinadns_ng_ip="${chinadns_ng_server%%:*}"
+				local chinadns_ng_port="${chinadns_ng_server##*:}"
+				[ "$chinadns_ng_ip" = "$chinadns_ng_port" ] && chinadns_ng_port="53"
+				chinadns_ng_tls_port="853"
+				case "$chinadns_ng_proto" in
+					"none")
+						chinadns_ng_server="${chinadns_ng_ip}#${chinadns_ng_port}"
+						;;
+					"tls")
+						chinadns_ng_server="${chinadns_ng_proto}://${chinadns_ng_ip}#${chinadns_ng_tls_port}"
+						;;
+					*)
+						chinadns_ng_server="${chinadns_ng_proto}://${chinadns_ng_ip}#${chinadns_ng_port}"
+						;;
+				esac
+					chinadns_ng_dns="${chinadns_ng_dns} -t ${chinadns_ng_server}"
+			done
+			unset IFS
+			dnsserver="$chinadns_ng_dns"
+			ln_start_bin $(first_type chinadns-ng) chinadns-ng -b 127.0.0.1 -l $tmp_dns_port -l $dns_port -p 3 -d gfw $dnsserver -N --filter-qtype 64,65 -f -r --cache 4096 --cache-stale 86400 --cache-refresh 20
+		fi
 	fi
-	#chinadns-ng
+	#chinadns-ng(china)
 	if [ "$(uci -q get "dhcp.@dnsmasq[0]._unused_ssrp_changed")" = "1" ]; then
 		icount=$(busybox ps -w | grep $TMP_BIN_PATH/chinadns-ng | grep -v grep | wc -l)
 		if [ "$icount" -lt 1 ]; then #如果进程挂掉就重启它


### PR DESCRIPTION
添加的chinadns-ng用于国外dns解析的原因是：按照作者所说主要是新版chinadns-ng深度优化了性能以及内存占用，所以内存占用更小且性能更强。