### PR TITLE
luci-app-ssr-plus: Use 'wget-ssl' - > 'curl' to solve the compatibility issue between the old and new versions of wget.

### DIFF
--- a/luci-app-ssr-plus/Makefile
+++ b/luci-app-ssr-plus/Makefile
@@ -38,7 +38,7 @@ LUCI_PKGARCH:=all
 LUCI_DEPENDS:= \
 	+coreutils +coreutils-base64 +dns2tcp +dnsmasq-full +@PACKAGE_dnsmasq_full_ipset +ipset +kmod-ipt-nat +jq \
 	+ip-full +iptables +iptables-mod-tproxy +lua +lua-neturl +libuci-lua +microsocks \
-	+tcping +resolveip +shadowsocksr-libev-ssr-check +wget-ssl \
+	+tcping +resolveip +shadowsocksr-libev-ssr-check +curl \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_V2ray:curl \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_V2ray:v2ray-core \
 	+PACKAGE_$(PKG_NAME)_INCLUDE_Xray:curl \

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -95,7 +95,7 @@ get_host_ip() {
 	if [ -z "$(echo $host | grep -E "([0-9]{1,3}[\.]){3}[0-9]{1,3}")" ]; then
 		if [ "$host" == "${host#*:[0-9a-fA-F]}" ]; then
 			ip=$(resolveip -4 -t 3 $host | awk 'NR==1{print}')
-			[ -z "$ip" ] && ip=$(wget -q -O- http://119.29.29.29/d?dn=$host | awk -F ';' '{print $1}')
+			[ -z "$ip" ] && ip=$(curl -sSL "http://119.29.29.29/d?dn=$host" | awk -F ';' '{print $1}')
 		fi
 	fi
 	[ -z "$ip" ] || uci_set_by_name $1 ip $ip

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -680,12 +680,12 @@ local function processData(szType, content)
 	result.switch_enable = switch_enable
 	return result
 end
--- wget
-local function wget(url)
+-- curl
+local function curl(url)
 	-- 清理URL中的隐藏字符
 	url = url:gsub("%s+$", ""):gsub("^%s+", ""):gsub("%z", "")
 
-	local stdout = luci.sys.exec('wget-ssl --timeout=20 --tries=3 -q --user-agent="Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36" --no-check-certificate -O- "' .. url .. '"')
+	local stdout = luci.sys.exec('curl -sSL --connect-timeout 20 --max-time 30 --retry 3 -A "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.157 Safari/537.36" --insecure --location "' .. url .. '"')
 	return trim(stdout)
 end
 
@@ -739,7 +739,7 @@ local execute = function()
 			luci.sys.init.stop(name)
 		end
 		for k, url in ipairs(subscribe_url) do
-			local raw = wget(url)
+			local raw = curl(url)
 			if #raw > 0 then
 				local nodes, szType
 				local groupHash = md5(url)

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/update.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/update.lua
@@ -150,7 +150,7 @@ end
 
 local function update(url, file, type, file2)
 	local Num = 1
-	local refresh_cmd = "wget --no-check-certificate -q -O /tmp/ssr-update." .. type .. " " .. url
+	local refresh_cmd = "curl -sSL --insecure -o /tmp/ssr-update." .. type .. " " .. url
 	local sret = luci.sys.call(refresh_cmd)
 	if sret == 0 then
 		if type == "gfw_data" then


### PR DESCRIPTION
经部分用户测试，使用wget存在新旧版本兼容性问题，从而存在可能导致订阅失败现象。因此，干脆将使用wget替换为使用curl，以解决wget新旧版本可能存在不兼容现象。