### PR TITLE
解决MosDNS无法自定义DNS服务器问题

### DIFF
--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua
@@ -138,7 +138,7 @@ o:depends("shunt_dns_mode", "2")
 o.description = translate("Custom DNS Server format as IP:PORT (default: 8.8.4.4:53)")
 o.datatype = "ip4addrport"
 
-o = s:option(ListValue, "shunt_mosdns_dnsserver", translate("Anti-pollution DNS Server"))
+o = s:option(Value, "shunt_mosdns_dnsserver", translate("Anti-pollution DNS Server"))
 o:value("tcp://8.8.4.4:53,tcp://8.8.8.8:53", translate("Google Public DNS"))
 o:value("tcp://208.67.222.222:53,tcp://208.67.220.220:53", translate("OpenDNS"))
 o:value("tcp://209.244.0.3:53,tcp://209.244.0.4:53", translate("Level 3 Public DNS-1 (209.244.0.3-4)"))
@@ -146,7 +146,7 @@ o:value("tcp://4.2.2.1:53,tcp://4.2.2.2:53", translate("Level 3 Public DNS-2 (4.
 o:value("tcp://4.2.2.3:53,tcp://4.2.2.4:53", translate("Level 3 Public DNS-3 (4.2.2.3-4)"))
 o:value("tcp://1.1.1.1:53,tcp://1.0.0.1:53", translate("Cloudflare DNS"))
 o:depends("shunt_dns_mode", "3")
-o.description = translate("Custom DNS Server for MosDNS")
+o.description = translate("Custom DNS Server format as tcp://IP:PORT or tls://DOMAIN:PORT (tcp://8.8.8.8 or tls://dns.google:853)")
 
 o = s:option(Flag, "shunt_mosdns_ipv6", translate("Disable IPv6 In MosDNS Query Mode (Shunt Mode)"))
 o:depends("shunt_dns_mode", "3")

--- a/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client.lua
+++ b/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client.lua
@@ -161,7 +161,7 @@ o.description = translate("Custom DNS Server format as IP:PORT (default: 8.8.4.4
 o.datatype = "ip4addrport"
 o.default = "8.8.4.4:53"
 
-o = s:option(ListValue, "tunnel_forward_mosdns", translate("Anti-pollution DNS Server"))
+o = s:option(Value, "tunnel_forward_mosdns", translate("Anti-pollution DNS Server"))
 o:value("tcp://8.8.4.4:53,tcp://8.8.8.8:53", translate("Google Public DNS"))
 o:value("tcp://208.67.222.222:53,tcp://208.67.220.220:53", translate("OpenDNS"))
 o:value("tcp://209.244.0.3:53,tcp://209.244.0.4:53", translate("Level 3 Public DNS-1 (209.244.0.3-4)"))
@@ -169,7 +169,7 @@ o:value("tcp://4.2.2.1:53,tcp://4.2.2.2:53", translate("Level 3 Public DNS-2 (4.
 o:value("tcp://4.2.2.3:53,tcp://4.2.2.4:53", translate("Level 3 Public DNS-3 (4.2.2.3-4)"))
 o:value("tcp://1.1.1.1:53,tcp://1.0.0.1:53", translate("Cloudflare DNS"))
 o:depends("pdnsd_enable", "4")
-o.description = translate("Custom DNS Server for MosDNS")
+o.description = translate("Custom DNS Server format as tcp://IP:PORT or tls://DOMAIN:PORT (tcp://8.8.8.8 or tls://dns.google:853)")
 
 o = s:option(Flag, "mosdns_ipv6", translate("Disable IPv6 in MOSDNS query mode"))
 o:depends("pdnsd_enable", "4")

--- a/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
+++ b/luci-app-ssr-plus/po/zh_Hans/ssr-plus.po
@@ -416,8 +416,8 @@ msgstr ""
 
 #: applications/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua:149
 #: applications/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/client.lua:172
-msgid "Custom DNS Server for MosDNS"
-msgstr "MosDNS 自定义 DNS 服务器"
+msgid "Custom DNS Server format as tcp://IP:PORT or tls://DOMAIN:PORT (tcp://8.8.8.8 or tls://dns.google:853)"
+msgstr "格式为tcp://IP:Port或tls://域名:Port (tcp://8.8.8.8或tls://dns.google:853)"
 
 #: applications/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua:138
 #: applications/luci-app-ssr-plus/luasrc/model/cbi/shadowsocksr/advanced.lua:220

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -241,7 +241,7 @@ start_dns() {
 				echo "              enable_pipeline: true"
 			done)
 
-			awk -v line=14 -v text="$output" 'NR == line+1 {print text} 1' /etc/ssrplus/mosdns-config.yaml | sed "s/DNS_PORT/$dns_port/g" > $TMP_PATH/mosdns-config.yaml
+			awk -v line=14 -v text="$output" 'NR == line+1 {print text} 1' /etc/ssrplus/mosdns-config.yaml | sed "s/DNS_PORT/$dns_port/g" | sed "s/\(concurrent:\).*/\1 $(echo "$mosdns_dnsserver" | sed 's/,/ /g' | wc -w)/g"> $TMP_PATH/mosdns-config.yaml
 			if [ "$mosdns_ipv6" == "0" ]; then
 				sed -i "s/DNS_MODE/main_sequence_with_IPv6/g" $TMP_PATH/mosdns-config.yaml
 			else
@@ -648,7 +648,7 @@ shunt_dns_command() {
 			echo "              socks5: \"127.0.0.1:$tmp_port\""
 			echo "              enable_pipeline: true"
 		done)
-		awk -v line=14 -v text="$output" 'NR == line+1 {print text} 1' /etc/ssrplus/mosdns-config.yaml | sed "s/DNS_PORT/$tmp_shunt_dns_port/g" > $TMP_PATH/mosdns-config-shunt.yaml
+		awk -v line=14 -v text="$output" 'NR == line+1 {print text} 1' /etc/ssrplus/mosdns-config.yaml | sed "s/DNS_PORT/$tmp_shunt_dns_port/g" | sed "s/\(concurrent:\).*/\1 $(echo "$mosdns_dnsserver" | sed 's/,/ /g' | wc -w)/g" > $TMP_PATH/mosdns-config-shunt.yaml
 
 		if [ "$shunt_mosdns_ipv6" == "0" ]; then
 			sed -i "s/DNS_MODE/main_sequence_with_IPv6/g" $TMP_PATH/mosdns-config-shunt.yaml


### PR DESCRIPTION
@zxlhhyccc
luci页面有MosDNS 自定义 DNS 服务器这个描述，但是却无法输入自定义服务器地址，修复了下。
<img width="1070" height="350" alt="image" src="https://github.com/user-attachments/assets/728168e5-b0ad-4766-a51e-e70a1aa3cd5e" />


不过输入需要完整的地址，比如tcp://4.2.2.1:53或者tcp://4.2.2.1:53,tcp://4.2.2.2:53或者 tls://xx.com:853这种格式。这个是否需要改下描述说明下