### PR TITLE
[dev] luci-app-ssr-plus: Fix drag failure issue when pagination.

### DIFF
--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/server_list.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/server_list.htm
@@ -275,11 +275,15 @@ end
 		}
 		var input = document.getElementById(store);
 		var order = ids.join(" ");
+		var pageElem = document.getElementById('cbi-server-page');
+		var pageSizeElem = document.getElementById('cbi-server-page-size');
+		var server_page = pageElem ? pageElem.value : '<%=self.server_page or 1%>';
+		var server_page_size = pageSizeElem ? pageSizeElem.value : '<%=self.server_page_size or 0%>';
 		if (input) input.value = order;
 		XHR.post('<%=luci.dispatcher.build_url("admin/services/shadowsocksr/save_order")%>', {
 			order: order,
-			page: '<%=self.server_page or 1%>',
-			page_size: '<%=self.server_page_size or 0%>'
+			page: server_page,
+			page_size: server_page_size
 		}, function(x, result) {
 			result = result || {};
 			if (result.ret !== 1 && result.ret !== "1") {

--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/server_table.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/server_table.htm
@@ -165,6 +165,8 @@ function render_pager()
 			<% end %>
 		</span>
 	</div>
+	<input type="hidden" id="cbi-server-page" value="<%=page%>" />
+	<input type="hidden" id="cbi-server-page-size" value="<%=page_size%>" />
 	<%
 end
 -%>


### PR DESCRIPTION
**问题情况：分页情况下，前端传递的节点是50个，实际后端（page的值为1，page_size值为0）的节点数是86个，两者校验不一致导致拖拽失败，见图：**

<img width="558" height="140" alt="image" src="https://github.com/user-attachments/assets/feb52801-fd8d-42af-bd30-fa6aaffbb919" />

<img width="213" height="110" alt="image" src="https://github.com/user-attachments/assets/4fb3f640-efce-472e-8199-36f94ad65608" />
