### PR TITLE
Fix XHR.post TypeError in LuCI new version

### DIFF
--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/clash_main_panel.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/clash_main_panel.htm
@@ -258,12 +258,68 @@ local current_sid = self.map:get(section, "global_server") or "nil"
 	</style>
 
 	<script type="text/javascript">
+	if (!window.ssrXHR) {
+		window.ssrXHR = (function() {
+			function encode(data) {
+				var pairs = [];
+				var key;
+				for (key in (data || {})) {
+					if (Object.prototype.hasOwnProperty.call(data, key)) {
+						pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key] == null ? '' : data[key]));
+					}
+				}
+				return pairs.join('&');
+			}
+
+			function request(method, url, data, callback) {
+				var lower = method.toLowerCase();
+				if (window.XHR && typeof window.XHR[lower] === 'function') {
+					return window.XHR[lower](url, data, callback);
+				}
+
+				var xhr = new XMLHttpRequest();
+				var payload = encode(data);
+				var finalUrl = url;
+
+				if (lower === 'get' && payload) {
+					finalUrl += (url.indexOf('?') === -1 ? '?' : '&') + payload;
+				}
+
+				xhr.open(method, finalUrl, true);
+				xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+				if (lower !== 'get') {
+					xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+				}
+				xhr.onreadystatechange = function() {
+					if (xhr.readyState !== 4) return;
+
+					var rv = null;
+					try {
+						rv = JSON.parse(xhr.responseText || 'null');
+					} catch (e) {}
+
+					if (callback) callback(xhr, rv);
+				};
+				xhr.send(lower === 'get' ? null : payload);
+			}
+
+			return {
+				get: function(url, data, callback) {
+					return request('GET', url, data, callback);
+				},
+				post: function(url, data, callback) {
+					return request('POST', url, data, callback);
+				}
+			};
+		})();
+	}
+
 	if (typeof(window.ssrClashRefreshSubscription) !== "function") {
 		window.ssrClashRefreshSubscription = function(btn, sid) {
 			var original = btn.value;
 			btn.disabled = true;
 			btn.value = '<%:Reloading YAML...%>';
-			XHR.get('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_refresh")%>', {
+			window.ssrXHR.get('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_refresh")%>', {
 				sid: sid
 			}, function(x, result) {
 				btn.disabled = false;
@@ -288,7 +344,7 @@ local current_sid = self.map:get(section, "global_server") or "nil"
 			}
 			btn.disabled = true;
 			btn.value = '<%:Resetting Defaults...%>';
-			XHR.get('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_reset_defaults")%>', {
+			window.ssrXHR.get('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_reset_defaults")%>', {
 				sid: sid
 			}, function(x, result) {
 				btn.disabled = false;
@@ -642,7 +698,7 @@ local current_sid = self.map:get(section, "global_server") or "nil"
 
 				select.onchange = function() {
 					setPanelStatus('<%:Switching...%>', '#0072c3');
-					XHR.get('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_switch")%>', {
+						window.ssrXHR.get('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_switch")%>', {
 						sid: currentPanelSid,
 						group: group.name,
 						name: select.value
@@ -699,7 +755,7 @@ local current_sid = self.map:get(section, "global_server") or "nil"
 				payload['rule_' + index + '_policy_group'] = rule.policy_group || '';
 			});
 
-			XHR.post('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_client_rule_save")%>', payload, function(x, result) {
+			window.ssrXHR.post('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_client_rule_save")%>', payload, function(x, result) {
 				btn.disabled = false;
 				btn.value = original;
 				if (result && result.success) {
@@ -733,7 +789,7 @@ local current_sid = self.map:get(section, "global_server") or "nil"
 			if (importBtn) importBtn.style.display = '';
 			if (refreshBtn) refreshBtn.style.display = 'none';
 
-			XHR.get('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_client_policies")%>', {
+			window.ssrXHR.get('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_client_policies")%>', {
 				sid: sid
 			}, function(x, result) {
 				if (!result || !result.active) {
@@ -785,7 +841,7 @@ local current_sid = self.map:get(section, "global_server") or "nil"
 			if (exportBtn) exportBtn.style.display = 'none';
 			if (importBtn) importBtn.style.display = 'none';
 			if (refreshBtn) refreshBtn.style.display = '';
-			XHR.get('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_groups")%>', {
+			window.ssrXHR.get('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_groups")%>', {
 				sid: sid
 			}, function(x, result) {
 				if (result && result.sid) {
@@ -955,7 +1011,7 @@ local current_sid = self.map:get(section, "global_server") or "nil"
 						return false;
 					}
 					modalRulesClearBtn.disabled = true;
-					XHR.post('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_client_rule_clear")%>', {
+					window.ssrXHR.post('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "clash_client_rule_clear")%>', {
 						sid: currentEditorSid
 					}, function(x, result) {
 						modalRulesClearBtn.disabled = false;

--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/server_list.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/server_list.htm
@@ -59,6 +59,62 @@ end
 
 <script type="text/javascript">
 		//<![CDATA[
+		if (!window.ssrXHR) {
+			window.ssrXHR = (function() {
+				function encode(data) {
+					var pairs = [];
+					var key;
+					for (key in (data || {})) {
+						if (Object.prototype.hasOwnProperty.call(data, key)) {
+							pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key] == null ? '' : data[key]));
+						}
+					}
+					return pairs.join('&');
+				}
+
+				function request(method, url, data, callback) {
+					var lower = method.toLowerCase();
+					if (window.XHR && typeof window.XHR[lower] === "function") {
+						return window.XHR[lower](url, data, callback);
+					}
+
+					var xhr = new XMLHttpRequest();
+					var payload = encode(data);
+					var finalUrl = url;
+
+					if (lower === "get" && payload) {
+						finalUrl += (url.indexOf('?') === -1 ? '?' : '&') + payload;
+					}
+
+					xhr.open(method, finalUrl, true);
+					xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+					if (lower !== "get") {
+						xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+					}
+					xhr.onreadystatechange = function() {
+						if (xhr.readyState !== 4) return;
+
+						var rv = null;
+						try {
+							rv = JSON.parse(xhr.responseText || 'null');
+						} catch (e) {}
+
+						if (callback) callback(xhr, rv);
+					};
+					xhr.send(lower === "get" ? null : payload);
+				}
+
+				return {
+					get: function(url, data, callback) {
+						return request('GET', url, data, callback);
+					},
+					post: function(url, data, callback) {
+						return request('POST', url, data, callback);
+					}
+				};
+			})();
+		}
+
 		window.addEventListener('load', function () {
 			const doms = document.getElementsByClassName('pingtime');
 			const ports = document.getElementsByClassName("socket-connected");
@@ -165,7 +221,7 @@ end
 						return;
 					}
 					port.innerHTML = '<font style=\"color:#0072c3\">connect</font>';
-						XHR.get('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "ping")%>', {
+							window.ssrXHR.get('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "ping")%>', {
 							index,
 							sid: dom.getAttribute("data-sid"),
 							domain: dom.getAttribute("hint"),
@@ -280,7 +336,7 @@ end
 		var server_page = pageElem ? pageElem.value : '<%=self.server_page or 1%>';
 		var server_page_size = pageSizeElem ? pageSizeElem.value : '<%=self.server_page_size or 0%>';
 		if (input) input.value = order;
-		XHR.post('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "save_order")%>', {
+		window.ssrXHR.post('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "save_order")%>', {
 			order: order,
 			page: server_page,
 			page_size: server_page_size

--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/server_table.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/server_table.htm
@@ -197,6 +197,77 @@ end
 
 <!-- tblsection -->
 <div class="cbi-section cbi-tblsection" id="cbi-<%=self.config%>-<%=self.sectiontype%>">
+	<script type="text/javascript">
+		if (!window.ssrXHR) {
+			window.ssrXHR = (function() {
+				function encode(data) {
+					var pairs = [];
+					var key;
+					for (key in (data || {})) {
+						if (Object.prototype.hasOwnProperty.call(data, key)) {
+							pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key] == null ? '' : data[key]));
+						}
+					}
+					return pairs.join('&');
+				}
+
+				function request(method, url, data, callback) {
+					var lower = method.toLowerCase();
+					if (window.XHR && typeof window.XHR[lower] === "function") {
+						return window.XHR[lower](url, data, callback);
+					}
+
+					var xhr = new XMLHttpRequest();
+					var payload = encode(data);
+					var finalUrl = url;
+
+					if (lower === "get" && payload) {
+						finalUrl += (url.indexOf('?') === -1 ? '?' : '&') + payload;
+					}
+
+					xhr.open(method, finalUrl, true);
+					xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+					if (lower !== "get") {
+						xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+					}
+					xhr.onreadystatechange = function() {
+						if (xhr.readyState !== 4) return;
+
+						var rv = null;
+						try {
+							rv = JSON.parse(xhr.responseText || 'null');
+						} catch (e) {}
+
+						if (callback) callback(xhr, rv);
+					};
+					xhr.send(lower === "get" ? null : payload);
+				}
+
+				return {
+					get: function(url, data, callback) {
+						return request('GET', url, data, callback);
+					},
+					post: function(url, data, callback) {
+						return request('POST', url, data, callback);
+					}
+				};
+			})();
+		}
+
+		if (typeof window.ssrDeleteNode !== "function") {
+			window.ssrDeleteNode = function(sid) {
+				window.ssrXHR.post('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "delete_node")%>', {
+					sid: sid
+				}, function(x, result) {
+					result = result || {};
+					if (result.ret == 1) {
+						window.location.reload();
+					}
+				});
+				return false;
+			};
+		}
+	</script>
 	<% if self.title and #self.title > 0 then -%>
 		<h3><%=self.title%></h3>
 	<%- end %>
@@ -244,22 +315,10 @@ end
 							%> onclick="location.href='<%=self:extedit(section)%>'"
 							<%- end
 							%> alt="<%:Edit%>" title="<%:Edit%>" />
-						<% end; if self.addremove then %>
-							<input class="btn cbi-button cbi-button-remove" type="button" value="<%:Delete%>"
-								onclick="
-									var sid = '<%=k%>';
-									XHR.post('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "delete_node")%>', {
-										sid: sid
-									}, function(x, result) {
-										result = result || {};
-										if (result.ret == 1) {
-											window.location.reload();
-											return;
-										}
-									});
-									return false;
-								"
-							/>
+							<% end; if self.addremove then %>
+								<input class="btn cbi-button cbi-button-remove" type="button" value="<%:Delete%>"
+									onclick="return window.ssrDeleteNode('<%=k%>')"
+								/>
 						<%- end -%>
 					</div>
 				</td>

--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/subscribe_actions_footer.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/subscribe_actions_footer.htm
@@ -20,6 +20,36 @@ local function width(o)
 end
 -%>
 <script type="text/javascript">//<![CDATA[
+	function ssrPost(url, data, callback) {
+		if (window.XHR && typeof window.XHR.post === 'function') {
+			return window.XHR.post(url, data, callback);
+		}
+
+		var xhr = new XMLHttpRequest();
+		var payload = [];
+		var key;
+		for (key in (data || {})) {
+			if (Object.prototype.hasOwnProperty.call(data, key)) {
+				payload.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key] == null ? '' : data[key]));
+			}
+		}
+
+		xhr.open('POST', url, true);
+		xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+		xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+		xhr.onreadystatechange = function() {
+			if (xhr.readyState !== 4) return;
+
+			var rv = null;
+			try {
+				rv = JSON.parse(xhr.responseText || 'null');
+			} catch (e) {}
+
+			if (callback) callback(xhr, rv);
+		};
+		xhr.send(payload.join('&'));
+	}
+
 	window.ssrUpdateSubscribeItem = window.ssrUpdateSubscribeItem || function(btn) {
 		if (!btn) return false;
 
@@ -72,9 +102,9 @@ end
 			for (var field in fields) {
 				var value = fields[field];
 				var promise = new Promise(function(resolve, reject) {
-					XHR.post(
-						'<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "toggle_subscribe_item_enabled")%>',
-						{ sid: sid, field: field, value: value },
+					ssrPost(
+							'<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "toggle_subscribe_item_enabled")%>',
+							{ sid: sid, field: field, value: value },
 						function(x, rv) {
 							if (rv && Number(rv.ret) === 1) {
 								resolve();
@@ -112,7 +142,7 @@ end
 		if (!confirm('<%:Are you sure you want to delete subscribe link: %s ?%>'.replace('%s', sid))) return;
 
 		btn.disabled = true;
-		XHR.post('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "delete_subscribe_item")%>',
+		ssrPost('<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "delete_subscribe_item")%>',
 			{ sid: sid },
 			function(x, rv) {
 				btn.disabled = false;
@@ -218,7 +248,7 @@ end
 		btn.disabled = true;
 		btn.value = '<%:Adding...%>';
 
-		XHR.post(
+		ssrPost(
 			'<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "add_subscribe_item")%>',
 			{},
 			function(x, rv) {

--- a/luci-app-ssr-plus/luasrc/view/shadowsocksr/subscribe_enabled_autosave.htm
+++ b/luci-app-ssr-plus/luasrc/view/shadowsocksr/subscribe_enabled_autosave.htm
@@ -1,5 +1,35 @@
 <script type="text/javascript">//<![CDATA[
 	(function() {
+		function ssrPost(url, data, callback) {
+			if (window.XHR && typeof window.XHR.post === 'function') {
+				return window.XHR.post(url, data, callback);
+			}
+
+			var xhr = new XMLHttpRequest();
+			var payload = [];
+			var key;
+			for (key in (data || {})) {
+				if (Object.prototype.hasOwnProperty.call(data, key)) {
+					payload.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key] == null ? '' : data[key]));
+				}
+			}
+
+			xhr.open('POST', url, true);
+			xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+			xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+			xhr.onreadystatechange = function() {
+				if (xhr.readyState !== 4) return;
+
+				var rv = null;
+				try {
+					rv = JSON.parse(xhr.responseText || 'null');
+				} catch (e) {}
+
+				if (callback) callback(xhr, rv);
+			};
+			xhr.send(payload.join('&'));
+		}
+
 		function bindSubscribeItemEnabledAutoSave() {
 			var root = document.getElementById('cbi-shadowsocksr-server_subscribe_item');
 			if (!root || root.getAttribute('data-enabled-autosave-bound') === '1') {
@@ -21,7 +51,7 @@
 				var original = target.checked;
 				target.disabled = true;
 
-				XHR.post(
+				ssrPost(
 					'<%=luci.dispatcher.build_url("admin", "services", "shadowsocksr", "toggle_subscribe_item_enabled")%>',
 					{ sid: sid, enabled: original ? '1' : '0' },
 					function(x, rv) {


### PR DESCRIPTION
兼容新版 LuCI 框架，这次的处理方式是统一加了 window.ssrXHR 兼容层：
• 如果当前 LuCI 环境里有原生 XHR.get/post，继续走原逻辑
• 如果没有，就自动回退到原生 XMLHttpRequest