### PR TITLE
luci-app-ssr-plus: fix three regressions in config generation and DNS startup

### DIFF
--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -1303,7 +1303,10 @@ start_dns() {
 			done
 			unset IFS  # 恢复默认分隔符
 			dnsserver="$chinadns_ng_dns"
-			ln_start_bin "$(first_type chinadns-ng)" chinadns-ng -b 127.0.0.1 -l "$tmp_dns_port" -l "$dns_port" -p 3 -d gfw "$dnsserver" -N --filter-qtype 64,65 -f -r --cache 4096 --cache-stale 86400 --cache-refresh 20
+			# $dnsserver holds a list of "-t <server>" arguments built above, so it
+			# has to stay unquoted and word-split into separate arguments
+			# shellcheck disable=SC2086
+			ln_start_bin "$(first_type chinadns-ng)" chinadns-ng -b 127.0.0.1 -l "$tmp_dns_port" -l "$dns_port" -p 3 -d gfw $dnsserver -N --filter-qtype 64,65 -f -r --cache 4096 --cache-stale 86400 --cache-refresh 20
 			echolog "ChinaDNS-NG query and cache Started!"
 			pdnsd_enable_flag=6
 			;;

--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -1529,14 +1529,14 @@ get_name() {
 gen_config_file() { #server1 type2 code3 local_port4 socks_port5 chain6 threads5
 	local server="$1"
 	local type="$2"
-	local mode="$3"
+	local code="$3"
 	local local_port="$4"
 	local socks_port="$5"
 	local chain="$6"
 	local tmp_port
 	local ss_protocol
 
-	case "$mode" in
+	case "$code" in
 	1)
 		config_file=$tcp_config_file
 		chain_config_file=$(echo "${config_file}" | sed 's/ssrplus\//ssrplus\/chain-/')
@@ -1563,7 +1563,7 @@ gen_config_file() { #server1 type2 code3 local_port4 socks_port5 chain6 threads5
 	case "$type" in
 	ss | ssr)
 		lua /usr/share/shadowsocksr/gen_config.lua "$server" "$mode" "$local_port" "${ss_protocol:-redir}" >"$config_file"
-		if [ "$mode" = "3" ]; then
+		if [ "$code" = "3" ]; then
 			lua /usr/share/shadowsocksr/gen_config.lua "$server" "$mode" "$tmp_port" socks >"$shunt_dns_config_file"
 		fi
 		;;
@@ -1571,7 +1571,7 @@ gen_config_file() { #server1 type2 code3 local_port4 socks_port5 chain6 threads5
 		lua /usr/share/shadowsocksr/gen_config.lua "$server" "$mode" "$local_port" "$socks_port" >"$config_file"
 		;;
 	trojan)
-		case "$mode" in
+		case "$code" in
 		1)
 			lua /usr/share/shadowsocksr/gen_config.lua "$server" nat "$local_port" >"$config_file"
 			;;
@@ -1588,7 +1588,7 @@ gen_config_file() { #server1 type2 code3 local_port4 socks_port5 chain6 threads5
 		esac
 		;;
 	naiveproxy)
-		case "$mode" in
+		case "$code" in
 		1)
 			lua /usr/share/shadowsocksr/gen_config.lua "$server" redir "$local_port" >"$config_file"
 			;;
@@ -1605,7 +1605,7 @@ gen_config_file() { #server1 type2 code3 local_port4 socks_port5 chain6 threads5
 		lua /usr/share/shadowsocksr/gen_config.lua "$server" "$mode" "$local_port" "$socks_port" >"$config_file"
 		;;
 	tuic)
-		case "$mode" in
+		case "$code" in
 		1|2|4)
 			lua /usr/share/shadowsocksr/gen_config.lua "$server" "$mode" "$local_port" >"$config_file"
 			;;
@@ -1619,7 +1619,7 @@ gen_config_file() { #server1 type2 code3 local_port4 socks_port5 chain6 threads5
 		esac
 		;;
 	shadowtls)
-		case "$mode" in
+		case "$code" in
 		1|2|4)
 			if [ -z "$chain" ]; then
 				lua /usr/share/shadowsocksr/gen_config.lua "$server" "$type" "$local_port" >"$chain_config_file"

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -4,12 +4,23 @@ require "luci.sys"
 local ucursor = require "luci.model.uci".cursor()
 local json = require "luci.jsonc"
 
-local server_section = arg[1]
-local proto          = arg[2] or "tcp"
-local local_port     = arg[3] or "0"
-local socks_port     = arg[4] or "0"
+-- An omitted value reaches us either as a missing argument or as an empty
+-- string, depending on whether the caller quoted the expansion. Empty strings
+-- are truthy in Lua, so "arg[n] or default" alone does not cover both.
+local function argv(n, default)
+	local value = arg[n]
+	if value == nil or value == "" then
+		return default
+	end
+	return value
+end
 
-local chain          = arg[5] or "0"
+local server_section = arg[1]
+local proto          = argv(2, "tcp")
+local local_port     = argv(3, "0")
+local socks_port     = argv(4, "0")
+
+local chain          = argv(5, "0")
 
 -- trim
 local function trim(text)


### PR DESCRIPTION
# luci-app-ssr-plus: 修复重构加引号引入的三处回归

## 概述

`737e5d7`（"luci-app-ssr-plus: Optimize the code."）重写了 init 脚本，其中一项改动是给大量表达式加上了引号。有三处因此改变了行为，原因是被加引号的表达式并不是单一值：

| # | 改动 | 后果 |
|---|---|---|
| 1 | `gen_config_file()` 中的 `local mode="$3"` | 遮蔽了脚本全局的 `mode`，`gen_config.lua` 收到的是配置编号而非协议串 |
| 2 | 传给 `gen_config.lua` 的 `"$socks_port"` | 省略的值变成 `""` 而非不传；而 `""` 在 Lua 中为 truthy |
| 3 | 传给 `chinadns-ng` 的 `"$dnsserver"` | 该变量装的是一串参数，不是一个值 |

三者的共同表现都是「服务显示运行正常，但流量不通」，并且会互相遮蔽：修好第一处才看得到第二处，修好第二处才看得到第三处。

## 1. `gen_config_file()` 遮蔽了全局 `mode`

函数自己的注释写明第三个参数是配置编号：

```sh
gen_config_file() { #server1 type2 code3 local_port4 socks_port5 chain6 threads5
```

原先 `$3` 只用于控制流；传给 `gen_config.lua` 的协议串来自脚本全局的 `mode`，由 `Start_Run` 设为 `tcp`、`udp` 或 `tcp,udp`。把第三个参数绑定到名为 `mode` 的局部变量后，两者被合并，导致全部 9 处 `gen_config.lua` 调用都收到了数字编号。

生成的配置因此带有 `"network": "1"`，`gen_config.lua` 中所有 `proto:find("tcp")` 判断随之失效，最终产生不出可用的入站。

修复：按函数自身注释，将该参数命名为 `code`。

## 2. 空参数在 Lua 中为 truthy

省略可选 socks 端口的调用方（例如主节点路径）：

```sh
gen_config_file "$GLOBAL_SERVER" "$type" 1 "$tcp_port"
```

`$5` 未设置。不加引号时它展开为空、`gen_config.lua` 收到 3 个参数；加引号后则会多传一个空字符串作为第 4 个参数。

`local socks_port = arg[4] or "0"` 只在 `nil` 时回退，因此 `socks_port` 变成 `""`。它绕过了 `socks_port ~= "0"` 这道守卫，而生成的入站中 `port = tonumber("") = nil`，该键直接从 JSON 中消失：

```json
{
  "protocol": "socks",
  "settings": { "udp": true, "mixed": true, "auth": "noauth" }
}
```

Xray 拒绝这个入站，TCP 透明代理与 UDP 中继因此都起不来。只要未启用全局 SOCKS5 代理，就会出现该问题。

修复：可选参数改由一个辅助函数读取，把 `nil` 和 `""` 一并映射到默认值，使脚本不依赖调用方是否加引号。

## 3. chinadns-ng 的上游列表必须保持词分割

在 ChinaDNS-NG 模式下，`start_dns` 把 `$dnsserver` 构造成一串参数：

```sh
chinadns_ng_dns="${chinadns_ng_dns} -t ${chinadns_ng_server}"
...
dnsserver="$chinadns_ng_dns"
```

加引号会把整个 `" -t <server>"` 作为单个参数传给 `chinadns-ng`，它因命令行非法而无法启动。而其后的 `echolog "ChinaDNS-NG query and cache Started!"` 是无条件执行的，掩盖了这次失败。

于是 `$dns_port` 上无人监听，第二个 `chinadns-ng` 实例把可信查询转发到空处——需要走隧道的域名无法解析，而直连的国内域名仍然正常。

修复：该展开保持不加引号，并附注释与 shellcheck 例外，说明此处的词分割是有意为之。

## 验证环境

- Rockchip / aarch64，iptables（非 nftables）
- 主节点：Xray，VLESS + REALITY
- 运行模式：绕过大陆
- DNS 模式：ChinaDNS-NG
- 全局 SOCKS5 代理：未启用

修复前：节点显示 Running，`ssr-rules` 报告成功，但没有任何代理流量通过。三处全部修复后：节点连接正常，两个 `chinadns-ng` 实例均在运行，被墙域名可正常解析。

## 排查过程（仅供参考）

1. 分别以未经修改的 `89911e6` 和 `737e5d7` 编译并安装。前者正常、后者不通，从而将原因收敛到这一个提交。
2. 对比两者生成的 Xray 配置：正常的是 `"network": "tcp,udp"`，异常的是 `"network": "1"` —— 由此定位到回归 1。
3. 修复后再次对比：异常配置中多出一个没有 `port` 键的 socks 入站，而全局 SOCKS5 代理从未启用 —— 由此定位到回归 2。
4. 再修复后，生成的配置已逐字节一致，`iptables-save` 输出也完全相同，但连接仍然失败。`netstat` 显示 `$dns_port` 上无监听、`chinadns-ng` 只有一个实例（应为两个），`nslookup` 超时 —— 由此定位到回归 3。

每一处修复都单独编译安装验证，确保每一步都有各自的实测依据，而非推断。