### PR TITLE
luci-app-ssr-plus: fix authenticated SOCKS5 startup

### DIFF
--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -965,20 +965,27 @@ start_socks5_udp_with_ipt2socks() {
 	local local_port="$2"
 	local threads="$3"
 	local ipt2socks_bin
-	local auth_opts=""
+	local server_ip
 	local _i
 
 	ipt2socks_bin="$(first_type ipt2socks)"
+	server_ip="$(get_host_ip "$sid")"
 
 	[ -x "$ipt2socks_bin" ] || return 1
+	[ -n "$server_ip" ] || {
+		echolog "UDP TPROXY Relay:Socks5 无法解析服务器地址。"
+		return 1
+	}
+	set --
 	if [ "$(uci_get_by_name "$sid" auth_enable 0)" = "1" ]; then
-		auth_opts="-a $(uci_get_by_name "$sid" username) -k $(uci_get_by_name "$sid" password)"
+		set -- -a "$(uci_get_by_name "$sid" username)" \
+			-k "$(uci_get_by_name "$sid" password)"
 	fi
 	for _i in $(seq 1 "$threads"); do
 		ln_start_bin "$ipt2socks_bin" ipt2socks -U -r -b 0.0.0.0 -4 \
-			-s "$(uci_get_by_name "$sid" server)" \
+			-s "$server_ip" \
 			-p "$(uci_get_by_name "$sid" server_port)" \
-			-l "$local_port" "$auth_opts"
+			-l "$local_port" "$@"
 	done
 	echolog "UDP TPROXY Relay:Socks5 via IPT2Socks $threads Threads Started!"
 	return 0
@@ -989,21 +996,28 @@ start_socks5_redir_with_ipt2socks() {
 	local local_port="$2"
 	local threads="$3"
 	local ipt2socks_bin
-	local auth_opts=""
+	local server_ip
 	local _i
 
 	ipt2socks_bin="$(first_type ipt2socks)"
+	server_ip="$(get_host_ip "$sid")"
 
 	[ -x "$ipt2socks_bin" ] || return 1
+	[ -n "$server_ip" ] || {
+		echolog "Main node:Socks5 无法解析服务器地址。"
+		return 1
+	}
+	set --
 	if [ "$(uci_get_by_name "$sid" auth_enable 0)" = "1" ]; then
-		auth_opts="-a $(uci_get_by_name "$sid" username) -k $(uci_get_by_name "$sid" password)"
+		set -- -a "$(uci_get_by_name "$sid" username)" \
+			-k "$(uci_get_by_name "$sid" password)"
 	fi
 	for _i in $(seq 1 "$threads"); do
 		ln_start_bin "$ipt2socks_bin" ipt2socks \
 			-T -R -r -b 0.0.0.0 -4 \
-			-s "$(uci_get_by_name "$sid" server)" \
+			-s "$server_ip" \
 			-p "$(uci_get_by_name "$sid" server_port)" \
-			-l "$local_port" "$auth_opts"
+			-l "$local_port" "$@"
 	done
 	echolog "Main node:Socks5 via IPT2Socks $threads Threads Started!"
 	return 0


### PR DESCRIPTION
## Summary

- resolve SOCKS5 server hostnames before passing them to `ipt2socks`
- pass username and password as distinct command arguments
- fail with a clear log message when hostname resolution fails
- apply the fix to both TCP redirect and UDP TPROXY startup paths

## Root cause

The authentication options were assembled into one string and then expanded as a single quoted argument. As a result, `ipt2socks` received `-a user -k password` as one argv entry instead of four entries and failed to start. In addition, the configured server value was passed directly to `ipt2socks -s`; a hostname therefore failed because this backend expects a resolved IPv4 address.

## Validation

- `sh -n luci-app-ssr-plus/root/etc/init.d/shadowsocksr`
- `git diff --check`
- validated on OpenWrt with luci-app-ssr-plus 196-r7 using an authenticated SOCKS5 hostname
- confirmed eight TCP and eight UDP ipt2socks workers, DNS2TCP operation, and proxied Google/GitHub access