### PR TITLE
Fix/ssrplus script fixes

### DIFF
--- a/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
+++ b/luci-app-ssr-plus/root/etc/init.d/shadowsocksr
@@ -1317,7 +1317,10 @@ start_dns() {
 			done
 			unset IFS  # 恢复默认分隔符
 			dnsserver="$chinadns_ng_dns"
-			ln_start_bin "$(first_type chinadns-ng)" chinadns-ng -b 127.0.0.1 -l "$tmp_dns_port" -l "$dns_port" -p 3 -d gfw "$dnsserver" -N --filter-qtype 64,65 -f -r --cache 4096 --cache-stale 86400 --cache-refresh 20
+			# $dnsserver holds a list of "-t <server>" arguments built above, so it
+			# has to stay unquoted and word-split into separate arguments
+			# shellcheck disable=SC2086
+			ln_start_bin "$(first_type chinadns-ng)" chinadns-ng -b 127.0.0.1 -l "$tmp_dns_port" -l "$dns_port" -p 3 -d gfw $dnsserver -N --filter-qtype 64,65 -f -r --cache 4096 --cache-stale 86400 --cache-refresh 20
 			echolog "ChinaDNS-NG query and cache Started!"
 			pdnsd_enable_flag=6
 			;;

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -4,12 +4,23 @@ require "luci.sys"
 local ucursor = require "luci.model.uci".cursor()
 local json = require "luci.jsonc"
 
-local server_section = arg[1]
-local proto          = arg[2] or "tcp"
-local local_port     = arg[3] or "0"
-local socks_port     = arg[4] or "0"
+-- An omitted value reaches us either as a missing argument or as an empty
+-- string, depending on whether the caller quoted the expansion. Empty strings
+-- are truthy in Lua, so "arg[n] or default" alone does not cover both.
+local function argv(n, default)
+	local value = arg[n]
+	if value == nil or value == "" then
+		return default
+	end
+	return value
+end
 
-local chain          = arg[5] or "0"
+local server_section = arg[1]
+local proto          = argv(2, "tcp")
+local local_port     = argv(3, "0")
+local socks_port     = argv(4, "0")
+
+local chain          = argv(5, "0")
 
 -- trim
 local function trim(text)


### PR DESCRIPTION
## 修复内容

### 1. chinadns-ng 上游列表保持 word-split

`start_dns()` 中 `$dnsserver` 是按循环拼接出的 `-t <server>` 参数列表，
对其加引号会让 chinadns-ng 收到一个包含整串 `" -t <server>"` 的参数而拒绝启动；
且"ChinaDNS-NG Started!"日志仍会打印，掩盖失败，导致 $dns_port 无人监听、
走隧道的域名无法解析。改为不引号展开（带注释与 shellcheck 例外说明是有意的）。

### 2. gen_config.lua 空参数按缺省处理

调用方省略可选参数时，可能传空串（取决于展开是否加引号）。Lua 中空串为真值，
`arg[n] or default` 无法兜底：socks 端口为 "" 时 `socks_port ~= "0"` 守卫失效，
生成的 inbound port 为 nil，Xray 拒绝启动。新增 argv() 辅助函数，将 nil 与 ""
统一映射为默认值。

## 提交

1. keep the chinadns-ng upstream list word-split
2. treat empty script arguments as absent in gen_config.lua