### PR TITLE
luci-app-ssr-plus: set a nameserver for mihomo's built-in DNS

### DIFF
--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/clash_yaml.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/clash_yaml.lua
@@ -306,6 +306,63 @@ local function prepare(input_path, output_path)
 	return true
 end
 
+local function get_wan_nameserver()
+	local f = io.open("/tmp/resolv.conf.d/resolv.conf.auto", "r")
+	if not f then
+		return nil
+	end
+
+	local ip
+	for line in f:lines() do
+		ip = line:match("^nameserver%s+(%d+%.%d+%.%d+%.%d+)%s*$")
+		if ip then
+			break
+		end
+	end
+	f:close()
+
+	return ip
+end
+
+-- With no nameserver configured, mihomo falls back to plaintext public
+-- resolvers, which are poisoned in the environment this package targets.
+-- Reuse the existing "Anti-pollution DNS Server" option and let the query
+-- follow the routing rules into the tunnel, which is the same semantic
+-- dns2tcp/dns2socks provide for the other DNS modes. respect-rules requires
+-- proxy-server-nameserver, so bootstrap it from the WAN-provided resolver.
+local function build_dns_upstreams()
+	local forward = uci:get_first("shadowsocksr", "global", "tunnel_forward", "8.8.4.4:53")
+	if forward == nil or forward == "" then
+		forward = "8.8.4.4:53"
+	end
+
+	return {
+		["respect-rules"] = true,
+		["proxy-server-nameserver"] = { "udp://" .. (get_wan_nameserver() or "223.5.5.5") .. ":53" },
+		nameserver = { "udp://" .. forward }
+	}
+end
+
+-- Only fills what the merged document is missing, so a subscription that
+-- ships its own dns.nameserver keeps it.
+local function fill_missing_dns_upstreams(doc)
+	if type(doc.dns) ~= "table" or not doc.dns.enable then
+		return 0
+	end
+
+	if has_nonempty_sequence(doc.dns.nameserver) then
+		return 0
+	end
+
+	for k, v in pairs(build_dns_upstreams()) do
+		if doc.dns[k] == nil then
+			doc.dns[k] = v
+		end
+	end
+
+	return 1
+end
+
 local function merge(raw_path, overlay_path, output_path)
 	local raw_doc, raw_err = load_yaml(raw_path)
 	if not raw_doc then
@@ -323,6 +380,7 @@ local function merge(raw_path, overlay_path, output_path)
 	local filled_groups = fill_empty_proxy_groups(raw_doc)
 	local stripped_rules = strip_incompatible_script_rules(raw_doc)
 	local merged = deep_merge(raw_doc, overlay_doc)
+	local filled_dns = fill_missing_dns_upstreams(merged)
 	local ok, rendered = pcall(lyaml.dump, { merged })
 	if not ok or not rendered then
 		io.stderr:write("dump_failed\n")
@@ -330,7 +388,7 @@ local function merge(raw_path, overlay_path, output_path)
 	end
 
 	write_file(output_path, rendered)
-	io.stdout:write(string.format("filled_groups=%d stripped_script_rules=%d\n", filled_groups, stripped_rules))
+	io.stdout:write(string.format("filled_groups=%d stripped_script_rules=%d filled_dns=%d\n", filled_groups, stripped_rules, filled_dns))
 	return true
 end
 
@@ -427,6 +485,21 @@ local function get_filter_aaaa()
 	return value
 end
 
+local function build_dns_section(dns_mode)
+	local dns = {
+		enable = dns_mode == "7",
+		["enhanced-mode"] = "redir-host",
+		listen = "127.0.0.1:5335",
+		ipv6 = get_filter_aaaa() ~= "1"
+	}
+
+	for k, v in pairs(build_dns_upstreams()) do
+		dns[k] = v
+	end
+
+	return dns
+end
+
 local function build_tuic_runtime_doc(sid, local_port, socks_port, mode)
 	local server = get_server_field(sid, "server", "")
 	local server_port = tonumber(get_server_field(sid, "server_port", "0")) or 0
@@ -503,12 +576,7 @@ local function build_tuic_runtime_doc(sid, local_port, socks_port, mode)
 		rules = { "MATCH,PROXY" },
 		tun = { enable = false },
 		profile = { ["store-selected"] = true },
-		dns = {
-			enable = dns_mode == "7",
-			["enhanced-mode"] = "redir-host",
-			listen = "127.0.0.1:5335",
-			ipv6 = get_filter_aaaa() ~= "1"
-		}
+		dns = build_dns_section(dns_mode)
 	}
 
 	if mode == "socks" then
@@ -944,12 +1012,7 @@ local function build_single_proxy_runtime_doc(proxy, local_port, socks_port, mod
 		rules = { "MATCH,PROXY" },
 		tun = { enable = false },
 		profile = { ["store-selected"] = true },
-		dns = {
-			enable = dns_mode == "7",
-			["enhanced-mode"] = "redir-host",
-			listen = "127.0.0.1:5335",
-			ipv6 = get_filter_aaaa() ~= "1"
-		}
+		dns = build_dns_section(dns_mode)
 	}
 
 	if mode == "socks" then
@@ -1219,12 +1282,7 @@ local function build_shadowsocks_runtime_doc(sid, local_port, socks_port, mode)
 		rules = { "MATCH,PROXY" },
 		tun = { enable = false },
 		profile = { ["store-selected"] = true },
-		dns = {
-			enable = dns_mode == "7",
-			["enhanced-mode"] = "redir-host",
-			listen = "127.0.0.1:5335",
-			ipv6 = get_filter_aaaa() ~= "1"
-		}
+		dns = build_dns_section(dns_mode)
 	}
 
 	local listen_port = tonumber(local_port)


### PR DESCRIPTION
修复 #2039。

### 问题

DNS 解析方式为 mihomo 内置 DNS（`pdnsd_enable=7`）时，插件生成的 `dns` 段没有 `nameserver`。mihomo 的配置解析是「先套内置默认值，再用 YAML 覆盖」（`config/config.go:604` → `:612`），所以缺失的键保留内置默认 —— v1.19.28 下是 `https://doh.pub/dns-query` 和 `tls://223.5.5.5:853`。两者虽然加密，但都是国内递归解析器，无法正确解析被封锁的域名，结果指向伪造 IP，表现为间歇性 TLS 握手失败。

`parseDNS` 里的 `len(cfg.NameServer) == 0` 校验对非空默认值不触发，所以问题完全静默，日志无任何提示。

两条路径无条件受影响（都不写 `dns.nameserver`）：

- `subscribe.lua:869` `buildMihomoSubscribeYaml()` —— 订阅聚合生成的「Mihomo 总节点」
- `clash_yaml.lua` 的 `build_tuic_runtime_doc` / `build_single_proxy_runtime_doc` / `build_shadowsocks_runtime_doc` —— 单节点运行时配置

自带 `dns:` 段的机场 Clash 订阅不受影响。

### 改动

项目已有「反污染 DNS 服务器」配置项 `tunnel_forward`，其他每种 DNS 模式都读取它（dns2tcp `init.d/shadowsocksr:166`、chinadns-ng `:1329`、mosdns `:1272`、dns2socks），只有 mihomo 路径忽略。本 PR 让 mihomo 路径复用它：

- `build_dns_upstreams()` —— 读 `tunnel_forward`，产出 `nameserver` / `respect-rules` / `proxy-server-nameserver`
- `build_dns_section()` —— 收拢原先三处逐字重复的 `dns` 表，修掉单节点生成器路径
- `fill_missing_dns_upstreams()` —— 在 `merge()` 中 `deep_merge` **之后**调用

`respect-rules` 让 DNS 查询跟随 `rules` 进入隧道，与 dns2tcp/dns2socks 为其他模式提供的语义一致（起作用的关键属性是在墙外完成解析，而非加密本身），并且不需要知道用户订阅中的策略组名称。

**填充只在缺失时进行。** 如果无条件写进 overlay，会因为 overlay 在 `deep_merge` 中优先而覆盖掉机场自带的 `dns.nameserver`，构成回归；放在 merge 之后按需填充可以避免，与已有的 `fill_empty_proxy_groups` 属同类处理。

### 对照 mihomo v1.19.28 源码确认

| 结论 | 出处 |
|---|---|
| `respect-rules` 开启且未显式指定策略组时，查询跟随 `rules`（`proxyName = dns.RespectRules`） | `config.go:1277-1278` |
| `respect-rules` 要求 `proxy-server-nameserver` 非空，否则拒绝启动 | `config.go:1407-1408` |
| `proxy-server-nameserver` 以 `respectRules=false` 解析，走直连，不会死锁 | `config.go:1437` |
| `udp://host:port` 受支持，缺省端口 53 | `config.go:1219` |

第二条意味着两者必须成对写入，本 PR 始终如此。

### 测试

- `luac -p` 语法检查通过
- 从改动后的文件中抽取被测函数、stub 掉 `uci` / `has_nonempty_sequence` / `get_filter_aaaa` 后跑了 22 项断言，全部通过。覆盖：
  - `dns` 段缺失 / `enable=false` / 缺 `nameserver` / `nameserver` 为空表
  - **已有 `nameserver` 时保持原样不覆盖**（回归防护）
  - 显式 `respect-rules: false` 不被改写
  - `tunnel_forward` 为空时回落默认、自定义值正确生效
  - `build_dns_section()` 在 `dns_mode` 为 `7` / 非 `7` 时的 `enable` 取值
- 环境：ImmortalWrt 25.12.1 r37978-cd0a06bfd3fd，Mihomo Meta v1.19.28

尚未在真机上跑过打包后的完整流程，如果需要我补真机验证结果请告知。

另外 issue 里问过、这里再提一下：`enhanced-mode` 硬编码为 `redir-host` 且 `strip_runtime_conflicts` 会移除 `fake-ip-range` / `fake-ip-filter`，我按「刻意设计」处理，本 PR 不涉及 fake-ip。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
