### PR TITLE
fix(ssr-plus): 修复 gRPC 节点订阅更新后 serviceName 丢失导致 xray 启动失败

### DIFF
--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/gen_config.lua
@@ -636,7 +636,7 @@ Xray.outbounds = {
 			} or nil,
 			grpcSettings = (server.transport == "grpc") and {
 				-- grpc
-				serviceName = (server.serviceName and server.serviceName ~= "") and server.serviceName or nil,
+				serviceName = (server.serviceName and server.serviceName ~= "") and server.serviceName or "",
 				multiMode = (server.grpc_mode == "multi") and true or nil,
 				idle_timeout = server.idle_timeout and (tonumber(server.idle_timeout) < 10 and 10 or tonumber(server.idle_timeout)) or nil,
 				health_check_timeout = server.health_check_timeout and tonumber(server.health_check_timeout) or nil,

--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -1379,7 +1379,7 @@ local function processData(szType, content, cfgid)
 				result.quic_security = params.quicSecurity or "none"
 				result.quic_key = params.key
 			elseif result.transport == "grpc" then
-				result.serviceName = params.serviceName
+				result.serviceName = params.serviceName or params.servicename or params.path
 				result.grpc_mode = params.mode or "gun"
 			elseif result.transport == "tcp" or result.transport == "raw" then
 				result.tcp_guise = params.headerType or "none"
@@ -1714,7 +1714,7 @@ local function processData(szType, content, cfgid)
 			result.quic_security = params.quicSecurity or "none"
 			result.quic_key = params.key
 		elseif result.transport == "grpc" then
-			result.serviceName = params.serviceName
+			result.serviceName = params.serviceName or params.servicename or params.path
 			result.grpc_mode = params.mode or "gun"
 		elseif result.transport == "tcp" or result.transport == "raw" then
 			result.tcp_guise = params.headerType and params.headerType ~= "" and params.headerType or "none"
@@ -1852,7 +1852,7 @@ local function processData(szType, content, cfgid)
 			result.quic_security = params.quicSecurity or "none"
 			result.quic_key = params.key
 		elseif result.transport == "grpc" then
-			result.serviceName = params.serviceName
+			result.serviceName = params.serviceName or params.servicename or params.path
 			result.grpc_mode = params.mode or "gun"
 		elseif result.transport == "raw" then
 			result.tcp_guise = params.headerType or "none"


### PR DESCRIPTION
### 问题

从订阅更新节点后，trojan-grpc / vless-grpc 节点必然启动失败，界面显示「未运行」，且无任何日志提示。实机排查发现是两个连环 bug：

### 根因

**1. subscribe.lua —— serviceName 键名大小写不匹配，永远取到 nil**

三处 gRPC 分支（trojan/vless/hysteria2 解析）存储查询参数时用 `params[string.lower(t[1])]` 把键名统一转成小写（如 `servicename`），读取时却用驼峰 `params.serviceName`，键名对不上，所有 gRPC 节点的 serviceName 解析结果恒为 nil。

**2. gen_config.lua —— 空 grpcSettings 被序列化成 JSON 数组，xray 拒收退出**

serviceName 为 nil 时，`grpcSettings` 表内字段可能全为 nil，`luci.jsonc` 会把这样的空表编码成 JSON 数组 `[]`（而非对象 `{}`），xray 24.x+ 配置校验失败直接退出进程。

两个 bug 叠加：订阅更新 → serviceName 丢失 → xray 崩溃 → 「未运行」，用户完全无法定位原因。

### 修复

- `subscribe.lua`（3 处）：`params.serviceName` 改为 `params.serviceName or params.servicename or params.path`，兼容大小写两种键名（path 与 serviceName 在多数机场链接中同值）；
- `gen_config.lua`（1 处）：serviceName 兜底为空字符串 `""`，保证 grpcSettings 始终序列化为 JSON 对象。

### 实机验证

- [x] ImmortalWrt + xray 24.x 实机，修补后订阅重新解析，gRPC 节点 serviceName 正确写入配置；
- [x] xray 正常常驻运行，通过节点 socks5 端口连测 `https://www.google.com/generate_204` 返回 204。